### PR TITLE
Add `ESSource` to copy PF-Clustering parameters to device

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/BuildFile.xml
@@ -15,6 +15,11 @@
 <use name="CalibCalorimetry/EcalTPGTools"/>
 <use name="DataFormats/HGCRecHit"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
+<use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/CUDACore"/>
+<use name="HeterogeneousCore/CUDAUtilities"/>
+<use name="CUDADataFormats/Common"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="vdt_headers"/>
 <use name="rootmath"/>
 <use name="root"/>

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h
@@ -1,0 +1,84 @@
+#ifndef RecoParticleFlow_PFClusterProducer_PFClusteringParamsGPU_h
+#define RecoParticleFlow_PFClusterProducer_PFClusteringParamsGPU_h
+
+#include <vector>
+
+#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_array.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+
+#include "CUDADataFormats/Common/interface/PortableDeviceCollection.h"
+#include "CUDADataFormats/Common/interface/PortableHostCollection.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+#ifndef __CUDACC__
+#include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
+#include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
+#endif
+
+namespace edm {
+  class ParameterSet;
+  class ParameterSetDescription;
+}
+
+class PFClusteringParamsGPU {
+public:
+  GENERATE_SOA_LAYOUT(ProductSoALayout,
+                      SOA_SCALAR(int32_t, nNeigh),
+                      SOA_SCALAR(float, seedPt2ThresholdEB),
+                      SOA_SCALAR(float, seedPt2ThresholdEE),
+                      SOA_COLUMN(float, seedEThresholdEB_vec),
+                      SOA_COLUMN(float, seedEThresholdEE_vec),
+                      SOA_COLUMN(float, topoEThresholdEB_vec),
+                      SOA_COLUMN(float, topoEThresholdEE_vec),
+                      SOA_SCALAR(float, showerSigma2),
+                      SOA_SCALAR(float, minFracToKeep),
+                      SOA_SCALAR(float, minFracTot),
+                      SOA_SCALAR(uint32_t, maxIterations),
+                      SOA_SCALAR(bool, excludeOtherSeeds),
+                      SOA_SCALAR(float, stoppingTolerance),
+                      SOA_SCALAR(float, minFracInCalc),
+                      SOA_SCALAR(float, minAllowedNormalization),
+                      SOA_COLUMN(float, recHitEnergyNormInvEB_vec),
+                      SOA_COLUMN(float, recHitEnergyNormInvEE_vec),
+                      SOA_SCALAR(float, barrelTimeResConsts_corrTermLowE),
+                      SOA_SCALAR(float, barrelTimeResConsts_threshLowE),
+                      SOA_SCALAR(float, barrelTimeResConsts_noiseTerm),
+                      SOA_SCALAR(float, barrelTimeResConsts_constantTermLowE2),
+                      SOA_SCALAR(float, barrelTimeResConsts_noiseTermLowE),
+                      SOA_SCALAR(float, barrelTimeResConsts_threshHighE),
+                      SOA_SCALAR(float, barrelTimeResConsts_constantTerm2),
+                      SOA_SCALAR(float, barrelTimeResConsts_resHighE2),
+                      SOA_SCALAR(float, endcapTimeResConsts_corrTermLowE),
+                      SOA_SCALAR(float, endcapTimeResConsts_threshLowE),
+                      SOA_SCALAR(float, endcapTimeResConsts_noiseTerm),
+                      SOA_SCALAR(float, endcapTimeResConsts_constantTermLowE2),
+                      SOA_SCALAR(float, endcapTimeResConsts_noiseTermLowE),
+                      SOA_SCALAR(float, endcapTimeResConsts_threshHighE),
+                      SOA_SCALAR(float, endcapTimeResConsts_constantTerm2),
+                      SOA_SCALAR(float, endcapTimeResConsts_resHighE2))
+
+  using HostProduct = cms::cuda::PortableHostCollection<ProductSoALayout<>>;
+  using DeviceProduct = cms::cuda::PortableDeviceCollection<ProductSoALayout<>>;
+
+#ifndef __CUDACC__
+  PFClusteringParamsGPU(edm::ParameterSet const&);
+  ~PFClusteringParamsGPU() = default;
+
+  static void fillDescription(edm::ParameterSetDescription& psetDesc);
+
+  DeviceProduct const& getProduct(cudaStream_t) const;
+
+private:
+  constexpr static uint32_t kMaxDepth_barrel = 4;
+  constexpr static uint32_t kMaxDepth_endcap = 7;
+
+  void setParameterValues(edm::ParameterSet const& iConfig);
+
+  HostProduct params_;
+  cms::cuda::ESProduct<DeviceProduct> product_;
+#endif
+};
+
+#endif // RecoParticleFlow_PFClusterProducer_PFClusteringParamsGPU_h

--- a/RecoParticleFlow/PFClusterProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/plugins/BuildFile.xml
@@ -1,4 +1,11 @@
-<library name="RecoParticleFlowPFClusterProducerPlugins" file="*.cc *.cu">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+
+<library name="RecoParticleFlowPFClusterProducerPlugins" file="*.cc ${cuda_src}">
   <use name="CondFormats/HcalObjects"/>
   <use name="CondFormats/EcalObjects"/>
   <use name="CondFormats/DataRecord"/>

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusteringParamsGPUESSource.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusteringParamsGPUESSource.cc
@@ -1,0 +1,51 @@
+#include <vector>
+#include <memory>
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+class PFClusteringParamsGPUESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  PFClusteringParamsGPUESSource(edm::ParameterSet const&);
+  ~PFClusteringParamsGPUESSource() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  std::unique_ptr<PFClusteringParamsGPU> produce(JobConfigurationGPURecord const&);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval&) override;
+
+private:
+  edm::ParameterSet const& pset_;
+};
+
+PFClusteringParamsGPUESSource::PFClusteringParamsGPUESSource(edm::ParameterSet const& pset) : pset_{pset} {
+  setWhatProduced(this);
+  findingRecord<JobConfigurationGPURecord>();
+}
+
+void PFClusteringParamsGPUESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
+                                                       const edm::IOVSyncValue& iTime,
+                                                       edm::ValidityInterval& oInterval) {
+  oInterval = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
+}
+
+void PFClusteringParamsGPUESSource::fillDescriptions(edm::ConfigurationDescriptions& desc) {
+  edm::ParameterSetDescription d;
+  d.setAllowAnything();
+  desc.addWithDefaultLabel(d);
+}
+
+std::unique_ptr<PFClusteringParamsGPU> PFClusteringParamsGPUESSource::produce(JobConfigurationGPURecord const&) {
+  return std::make_unique<PFClusteringParamsGPU>(pset_);
+}
+
+#include "FWCore/Framework/interface/SourceFactory.h"
+DEFINE_FWK_EVENTSETUP_SOURCE(PFClusteringParamsGPUESSource);

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusteringParamsGPU.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusteringParamsGPU.cc
@@ -1,0 +1,142 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+#include <cmath>
+
+PFClusteringParamsGPU::PFClusteringParamsGPU(edm::ParameterSet const& iConfig)
+ : params_(7) { setParameterValues(iConfig); }
+
+PFClusteringParamsGPU::DeviceProduct const& PFClusteringParamsGPU::getProduct(cudaStream_t cudaStream) const {
+  auto const& ret = product_.dataForCurrentDeviceAsync(
+      cudaStream, [this](DeviceProduct& product, cudaStream_t cudaStream) {
+        product = DeviceProduct(params_->metadata().size(), cudaStream);
+        cudaCheck(cudaMemcpyAsync(product.buffer().get(),
+                                  params_.const_buffer().get(),
+                                  params_.bufferSize(),
+                                  cudaMemcpyHostToDevice,
+                                  cudaStream));
+      });
+
+  return ret;
+}
+
+void PFClusteringParamsGPU::setParameterValues(edm::ParameterSet const& iConfig) {
+  auto view = params_.view();
+
+  // seedFinder
+  auto const& sfConf = iConfig.getParameterSet("seedFinder");
+  view.nNeigh() = sfConf.getParameter<int>("nNeighbours");
+  auto const& seedFinderConfs = sfConf.getParameterSetVector("thresholdsByDetector");
+  for (auto const& pset : seedFinderConfs) {
+    auto const& det = pset.getParameter<std::string>("detector");
+    auto seedPt2Threshold = std::pow(pset.getParameter<double>("seedingThresholdPt"), 2.);
+    auto const& thresholds = pset.getParameter<std::vector<double>>("seedingThreshold");
+    if (det == "HCAL_BARREL1") {
+      if (thresholds.size() != kMaxDepth_barrel)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_barrel << ") for \"\" vector of det = \"" << det << "\"";
+      view.seedPt2ThresholdEB() = seedPt2Threshold;
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.seedEThresholdEB_vec()[idx] = thresholds[idx];
+      }
+    } else if (det == "HCAL_ENDCAP") {
+      if (thresholds.size() != kMaxDepth_endcap)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_endcap << ") for \"\" vector of det = \"" << det << "\"";
+      view.seedPt2ThresholdEE() = seedPt2Threshold;
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.seedEThresholdEE_vec()[idx] = thresholds[idx];
+      }
+    } else {
+      throw cms::Exception("InvalidConfiguration") << "Unknown detector when parsing seedFinder: " << det;
+    }
+  }
+
+  // initialClusteringStep
+  auto const& initConf = iConfig.getParameterSet("initialClusteringStep");
+  auto const& topoThresholdConf = initConf.getParameterSetVector("thresholdsByDetector");
+  for (auto const& pset : topoThresholdConf) {
+    auto const& det = pset.getParameter<std::string>("detector");
+    auto const& thresholds = pset.getParameter<std::vector<double>>("gatheringThreshold");
+    if (det == "HCAL_BARREL1") {
+      if (thresholds.size() != kMaxDepth_barrel)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_barrel << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.topoEThresholdEB_vec()[idx] = thresholds[idx];
+      }
+    } else if (det == "HCAL_ENDCAP") {
+      if (thresholds.size() != kMaxDepth_endcap)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_endcap << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.topoEThresholdEE_vec()[idx] = thresholds[idx];
+      }
+    } else {
+      throw cms::Exception("InvalidConfiguration") << "Unknown detector when parsing initClusteringStep: " << det;
+    }
+  }
+
+  // pfClusterBuilder
+  auto const & pfClusterPSet = iConfig.getParameterSet("pfClusterBuilder");
+  view.showerSigma2() = std::pow(pfClusterPSet.getParameter<double>("showerSigma"), 2.);
+  view.minFracToKeep() = pfClusterPSet.getParameter<double>("minFractionToKeep");
+  view.minFracTot() = pfClusterPSet.getParameter<double>("minFracTot");
+  view.maxIterations() = pfClusterPSet.getParameter<unsigned int>("maxIterations");
+  view.excludeOtherSeeds() = pfClusterPSet.getParameter<bool>("excludeOtherSeeds");
+  view.stoppingTolerance() = pfClusterPSet.getParameter<double>("stoppingTolerance");
+  auto const& pcPSet = pfClusterPSet.getParameterSet("positionCalc");
+  view.minFracInCalc() = pcPSet.getParameter<double>("minFractionInCalc");
+  view.minAllowedNormalization() = pcPSet.getParameter<double>("minAllowedNormalization");
+
+  auto const& recHitEnergyNormConf = pfClusterPSet.getParameterSetVector("recHitEnergyNorms");
+  for (auto const& pset : recHitEnergyNormConf) {
+    auto const& recHitNorms = pset.getParameter<std::vector<double>>("recHitEnergyNorm");
+    auto const& det = pset.getParameter<std::string>("detector");
+    if (det == "HCAL_BARREL1") {
+      if (recHitNorms.size() != kMaxDepth_barrel)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << recHitNorms.size() << " != " << kMaxDepth_barrel << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < recHitNorms.size(); ++idx) {
+        view.recHitEnergyNormInvEB_vec()[idx] = 1. / recHitNorms[idx];
+      }
+    } else if (det == "HCAL_ENDCAP") {
+      if (recHitNorms.size() != kMaxDepth_endcap)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << recHitNorms.size() << " != " << kMaxDepth_endcap << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < recHitNorms.size(); ++idx) {
+        view.recHitEnergyNormInvEE_vec()[idx] = 1. / recHitNorms[idx];
+      }
+    } else {
+      throw cms::Exception("InvalidConfiguration") << "Unknown detector when parsing recHitEnergyNorms: " << det;
+    }
+  }
+
+  auto const& barrelTimeResConf = pfClusterPSet.getParameterSet("timeResolutionCalcBarrel");
+  view.barrelTimeResConsts_corrTermLowE() = barrelTimeResConf.getParameter<double>("corrTermLowE");
+  view.barrelTimeResConsts_threshLowE() = barrelTimeResConf.getParameter<double>("threshLowE");
+  view.barrelTimeResConsts_noiseTerm() = barrelTimeResConf.getParameter<double>("noiseTerm");
+  view.barrelTimeResConsts_constantTermLowE2() = std::pow(barrelTimeResConf.getParameter<double>("constantTermLowE"), 2.);
+  view.barrelTimeResConsts_noiseTermLowE() = barrelTimeResConf.getParameter<double>("noiseTermLowE");
+  view.barrelTimeResConsts_threshHighE() = barrelTimeResConf.getParameter<double>("threshHighE");
+  view.barrelTimeResConsts_constantTerm2() = std::pow(barrelTimeResConf.getParameter<double>("constantTerm"), 2.);
+  view.barrelTimeResConsts_resHighE2() = std::pow(view.barrelTimeResConsts_noiseTerm() / view.barrelTimeResConsts_threshHighE(), 2.)
+    + view.barrelTimeResConsts_constantTerm2();
+
+  auto const& endcapTimeResConf = pfClusterPSet.getParameterSet("timeResolutionCalcEndcap");
+  view.endcapTimeResConsts_corrTermLowE() = endcapTimeResConf.getParameter<double>("corrTermLowE");
+  view.endcapTimeResConsts_threshLowE() = endcapTimeResConf.getParameter<double>("threshLowE");
+  view.endcapTimeResConsts_noiseTerm() = endcapTimeResConf.getParameter<double>("noiseTerm");
+  view.endcapTimeResConsts_constantTermLowE2() = std::pow(endcapTimeResConf.getParameter<double>("constantTermLowE"), 2.);
+  view.endcapTimeResConsts_noiseTermLowE() = endcapTimeResConf.getParameter<double>("noiseTermLowE");
+  view.endcapTimeResConsts_threshHighE() = endcapTimeResConf.getParameter<double>("threshHighE");
+  view.endcapTimeResConsts_constantTerm2() = std::pow(endcapTimeResConf.getParameter<double>("constantTerm"), 2.);
+  view.endcapTimeResConsts_resHighE2() = std::pow(view.endcapTimeResConsts_noiseTerm() / view.endcapTimeResConsts_threshHighE(), 2.)
+    + view.endcapTimeResConsts_constantTerm2();
+}
+
+void PFClusteringParamsGPU::fillDescription(edm::ParameterSetDescription& psetDesc) {
+  //!! FIXME
+  psetDesc.setAllowAnything();
+}
+
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(PFClusteringParamsGPU);

--- a/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
@@ -17,3 +17,19 @@
   <use name="root"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+
+<library name="TestDumpPFClusteringParamsGPU" file="TestDumpPFClusteringParamsGPU.cc ${cuda_src}">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="RecoParticleFlow/PFClusterProducer"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoParticleFlow/PFClusterProducer/test/TestDumpPFClusteringParamsGPU.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/TestDumpPFClusteringParamsGPU.cc
@@ -1,0 +1,52 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
+#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+#include "testKernels.h"
+
+class TestDumpPFClusteringParamsGPU : public edm::stream::EDProducer<edm::ExternalWork> {
+public:
+  explicit TestDumpPFClusteringParamsGPU(edm::ParameterSet const&);
+  ~TestDumpPFClusteringParamsGPU() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void acquire(edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) override;
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+  edm::ESGetToken<PFClusteringParamsGPU, JobConfigurationGPURecord> const pfClusParamsToken_;
+
+  cms::cuda::ContextState cudaState_;
+};
+
+TestDumpPFClusteringParamsGPU::TestDumpPFClusteringParamsGPU(edm::ParameterSet const& ps)
+    : pfClusParamsToken_{esConsumes()} {
+}
+
+void TestDumpPFClusteringParamsGPU::fillDescriptions(edm::ConfigurationDescriptions& desc) {
+  edm::ParameterSetDescription psetDesc;
+  PFClusteringParamsGPU::fillDescription(psetDesc);
+  desc.addWithDefaultLabel(psetDesc);
+}
+
+void TestDumpPFClusteringParamsGPU::acquire(edm::Event const& event,
+                             edm::EventSetup const& setup,
+                             edm::WaitingTaskWithArenaHolder holder) {
+  cms::cuda::ScopedContextAcquire ctx{event.streamID(), std::move(holder), cudaState_};
+  auto const& pfClusParamsProduct = setup.getData(pfClusParamsToken_).getProduct(ctx.stream());
+  testPFlow::testPFClusteringParamsEntryPoint(pfClusParamsProduct, ctx.stream());
+}
+
+void TestDumpPFClusteringParamsGPU::produce(edm::Event& event, edm::EventSetup const& setup) {
+  cms::cuda::ScopedContextProduce ctx{cudaState_};
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TestDumpPFClusteringParamsGPU);

--- a/RecoParticleFlow/PFClusterProducer/test/testKernels.cu
+++ b/RecoParticleFlow/PFClusterProducer/test/testKernels.cu
@@ -1,0 +1,69 @@
+#include <cuda_runtime.h>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include "testKernels.h"
+
+namespace testPFlowCUDA {
+
+  __global__ void printPFClusteringParamsOnGPU(PFClusteringParamsGPU::DeviceProduct::ConstView params){
+
+    printf("nNeigh: %d\n", params.nNeigh());
+    printf("seedPt2ThresholdEB: %4.2f\n", params.seedPt2ThresholdEB());
+    printf("seedPt2ThresholdEE: %4.2f\n", params.seedPt2ThresholdEE());
+
+    for (uint32_t idx = 0; idx < 4; ++idx)
+      printf("seedEThresholdEB_vec[%d]: %4.2f\n", idx, params.seedEThresholdEB_vec()[idx]);
+    for (uint32_t idx = 0; idx < 7; ++idx)
+      printf("seedEThresholdEE_vec[%d]: %4.2f\n", idx, params.seedEThresholdEE_vec()[idx]);
+
+    for (uint32_t idx = 0; idx < 4; ++idx)
+      printf("topoEThresholdEB_vec[%d]: %4.2f\n", idx, params.topoEThresholdEB_vec()[idx]);
+    for (uint32_t idx = 0; idx < 7; ++idx)
+      printf("topoEThresholdEE_vec[%d]: %4.2f\n", idx, params.topoEThresholdEE_vec()[idx]);
+
+    printf("showerSigma2: %4.2f\n", params.showerSigma2());
+    printf("minFracToKeep: %4.2f\n", params.minFracToKeep());
+    printf("minFracTot: %4.2f\n", params.minFracTot());
+    printf("maxIterations: %d\n", params.maxIterations());
+    printf("excludeOtherSeeds: %d\n", params.excludeOtherSeeds());
+    printf("stoppingTolerance: %4.2f\n", params.stoppingTolerance());
+    printf("minFracInCalc: %4.2f\n", params.minFracInCalc());
+    printf("minAllowedNormalization: %4.2f\n", params.minAllowedNormalization());
+
+    for (uint32_t idx = 0; idx < 4; ++idx)
+      printf("recHitEnergyNormInvEB_vec[%d]: %4.2f\n", idx, params.recHitEnergyNormInvEB_vec()[idx]);
+    for (uint32_t idx = 0; idx < 7; ++idx)
+      printf("recHitEnergyNormInvEE_vec[%d]: %4.2f\n", idx, params.recHitEnergyNormInvEE_vec()[idx]);
+
+    printf("barrelTimeResConsts_corrTermLowE: %4.2f\n", params.barrelTimeResConsts_corrTermLowE());
+    printf("barrelTimeResConsts_threshLowE: %4.2f\n", params.barrelTimeResConsts_threshLowE());
+    printf("barrelTimeResConsts_noiseTerm: %4.2f\n", params.barrelTimeResConsts_noiseTerm());
+    printf("barrelTimeResConsts_constantTermLowE2: %4.2f\n", params.barrelTimeResConsts_constantTermLowE2());
+    printf("barrelTimeResConsts_noiseTermLowE: %4.2f\n", params.barrelTimeResConsts_noiseTermLowE());
+    printf("barrelTimeResConsts_threshHighE: %4.2f\n", params.barrelTimeResConsts_threshHighE());
+    printf("barrelTimeResConsts_constantTerm2: %4.2f\n", params.barrelTimeResConsts_constantTerm2());
+    printf("barrelTimeResConsts_resHighE2: %4.2f\n", params.barrelTimeResConsts_resHighE2());
+
+    printf("endcapTimeResConsts_corrTermLowE: %4.2f\n", params.endcapTimeResConsts_corrTermLowE());
+    printf("endcapTimeResConsts_threshLowE: %4.2f\n", params.endcapTimeResConsts_threshLowE());
+    printf("endcapTimeResConsts_noiseTerm: %4.2f\n", params.endcapTimeResConsts_noiseTerm());
+    printf("endcapTimeResConsts_constantTermLowE2: %4.2f\n", params.endcapTimeResConsts_constantTermLowE2());
+    printf("endcapTimeResConsts_noiseTermLowE: %4.2f\n", params.endcapTimeResConsts_noiseTermLowE());
+    printf("endcapTimeResConsts_threshHighE: %4.2f\n", params.endcapTimeResConsts_threshHighE());
+    printf("endcapTimeResConsts_constantTerm2: %4.2f\n", params.endcapTimeResConsts_constantTerm2());
+    printf("endcapTimeResConsts_resHighE2: %4.2f\n", params.endcapTimeResConsts_resHighE2());
+  }
+
+}
+
+namespace testPFlow {
+
+  void testPFClusteringParamsEntryPoint(
+    PFClusteringParamsGPU::DeviceProduct const& pfClusParams,
+    cudaStream_t cudaStream
+  ) {
+    testPFlowCUDA::printPFClusteringParamsOnGPU<<<1, 1, 0, cudaStream>>>(pfClusParams.const_view());
+  }
+
+}

--- a/RecoParticleFlow/PFClusterProducer/test/testKernels.h
+++ b/RecoParticleFlow/PFClusterProducer/test/testKernels.h
@@ -1,0 +1,15 @@
+#ifndef RecoParticleFlow_PFClusterProducer_test_testKernels_h
+#define RecoParticleFlow_PFClusterProducer_test_testKernels_h
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+namespace testPFlow {
+
+  void testPFClusteringParamsEntryPoint(
+    PFClusteringParamsGPU::DeviceProduct const& pfClusParams,
+    cudaStream_t cudaStream
+  );
+
+}
+
+#endif  // RecoParticleFlow_PFClusterProducer_test_testKernels_h

--- a/RecoParticleFlow/PFClusterProducer/test/testPFClusParamsGPU_cfg.py
+++ b/RecoParticleFlow/PFClusterProducer/test/testPFClusParamsGPU_cfg.py
@@ -1,0 +1,109 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+###
+### EDM Input and job configuration
+###
+process.source = cms.Source("EmptySource")
+
+# limit the number of events to be processed
+process.maxEvents.input = 50
+
+# enable TrigReport, TimeReport and MultiThreading
+process.options.wantSummary = True
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 0
+
+###
+### ESModules, EDModules, Sequences, Tasks, Paths, EndPaths and Schedule
+###
+process.load("Configuration.StandardSequences.Accelerators_cff")
+
+process.PFClusteringParamsGPUESSource = cms.ESSource("PFClusteringParamsGPUESSource",
+  seedFinder = cms.PSet(
+    nNeighbours = cms.int32( 4 ),
+    thresholdsByDetector = cms.VPSet(
+      cms.PSet(
+        detector = cms.string( "HCAL_BARREL1" ),
+        depths = cms.vint32( 1, 2, 3, 4 ),
+        seedingThreshold = cms.vdouble( 0.125, 0.25, 0.35, 0.35 ),
+        seedingThresholdPt = cms.double( 0.0 )
+      ),
+      cms.PSet(  detector = cms.string( "HCAL_ENDCAP" ),
+        depths = cms.vint32( 1, 2, 3, 4, 5, 6, 7 ),
+        seedingThreshold = cms.vdouble( 0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275 ),
+        seedingThresholdPt = cms.double( 0.0 )
+      )
+    ),
+  ),
+  initialClusteringStep = cms.PSet(
+    thresholdsByDetector = cms.VPSet(
+      cms.PSet(
+        detector = cms.string( "HCAL_BARREL1" ),
+        gatheringThreshold = cms.vdouble( 0.1, 0.2, 0.3, 0.3 ),
+      ),
+      cms.PSet(
+        detector = cms.string( "HCAL_ENDCAP" ),
+        gatheringThreshold = cms.vdouble( 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 ),
+      )
+    ),
+  ),
+  pfClusterBuilder = cms.PSet(
+    maxIterations = cms.uint32( 5 ),
+    minFracTot = cms.double( 1.0E-20 ),
+    minFractionToKeep = cms.double( 1.0E-7 ),
+    excludeOtherSeeds = cms.bool( True ),
+    showerSigma = cms.double( 10.0 ),
+    stoppingTolerance = cms.double( 1.0E-8 ),
+    positionCalc = cms.PSet(
+      minAllowedNormalization = cms.double( 1.0E-9 ),
+      posCalcNCrystals = cms.int32( 5 ),
+      minFractionInCalc = cms.double( 1.0E-9 ),
+      logWeightDenominatorByDetector = cms.VPSet(
+        cms.PSet(  depths = cms.vint32( 1, 2, 3, 4 ),
+          detector = cms.string( "HCAL_BARREL1" ),
+          logWeightDenominator = cms.vdouble( 0.1, 0.2, 0.3, 0.3 )
+        ),
+        cms.PSet(  depths = cms.vint32( 1, 2, 3, 4, 5, 6, 7 ),
+          detector = cms.string( "HCAL_ENDCAP" ),
+          logWeightDenominator = cms.vdouble( 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 )
+        )
+      )
+    ),
+    recHitEnergyNorms = cms.VPSet(
+      cms.PSet(  detector = cms.string( "HCAL_BARREL1" ),
+        recHitEnergyNorm = cms.vdouble( 0.1, 0.2, 0.3, 0.3 )
+      ),
+      cms.PSet(  detector = cms.string( "HCAL_ENDCAP" ),
+        recHitEnergyNorm = cms.vdouble( 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 )
+      )
+    ),
+    timeResolutionCalcBarrel = cms.PSet(
+      corrTermLowE = cms.double( 0.0 ),
+      threshLowE = cms.double( 6.0 ),
+      noiseTerm = cms.double( 21.86 ),
+      constantTermLowE = cms.double( 4.24 ),
+      noiseTermLowE = cms.double( 8.0 ),
+      threshHighE = cms.double( 15.0 ),
+      constantTerm = cms.double( 2.82 )
+    ),
+    timeResolutionCalcEndcap = cms.PSet(
+      corrTermLowE = cms.double( 0.0 ),
+      threshLowE = cms.double( 6.0 ),
+      noiseTerm = cms.double( 21.86 ),
+      constantTermLowE = cms.double( 4.24 ),
+      noiseTermLowE = cms.double( 8.0 ),
+      threshHighE = cms.double( 15.0 ),
+      constantTerm = cms.double( 2.82 )
+    ),
+  )
+)
+
+process.theProducer = cms.EDProducer("TestDumpPFClusteringParamsGPU")
+
+process.theSequence = cms.Sequence( process.theProducer )
+
+process.thePath = cms.Path( process.theSequence )
+
+process.schedule = cms.Schedule( process.thePath )


### PR DESCRIPTION
This PR adds an ESSource to copy to device the (constant) parameters of the PF-Clustering producer. The parameters are grouped in, and copied to device as, an SoA object per experts' suggestion, in order to ease the future port of this piece of sw to Alpaka.

Related test code is added in `RecoParticleFlow/PFClusterProducer/test/`. A test can be run as follows:
```sh
cmsRun "${CMSSW_BASE}"/src/RecoParticleFlow/PFClusterProducer/test/testPFClusParamsGPU_cfg.py
```
