### PR TITLE
Copy PF-Clustering parameters to device via `ESSource`

### DIFF
--- a/RecoParticleFlow/Configuration/test/run_HBHEandPF_onCPUandGPU.py
+++ b/RecoParticleFlow/Configuration/test/run_HBHEandPF_onCPUandGPU.py
@@ -110,6 +110,9 @@ associatePatAlgosToolsTask(process)
 process.load("RecoParticleFlow.PFClusterProducer.pfhbheRecHitParamsGPUESProducer_cfi")
 process.load("RecoParticleFlow.PFClusterProducer.pfhbheTopologyGPUESProducer_cfi")
 
+from RecoParticleFlow.PFClusterProducer.pfClusteringParamsGPUESSource_cfi import pfClusteringParamsGPUESSource as _pfClusteringParamsGPUESSource
+process.pfClusteringParamsGPUESSource = _pfClusteringParamsGPUESSource.clone()
+
 # Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforPatatrack
 #from HLTrigger.Configuration.customizeHLTforPatatrack import customizeHLTforPatatrack, customiseCommon, customiseHcalLocalReconstruction
 

--- a/RecoParticleFlow/Configuration/test/testPFOnGPUvsCPU_HBHE.sh
+++ b/RecoParticleFlow/Configuration/test/testPFOnGPUvsCPU_HBHE.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+[ ! -z "${CMSSW_BASE}" ] || exit 1
+
+cmsRun "${CMSSW_BASE}"/src/RecoParticleFlow/Configuration/test/run_HBHEandPF_onCPUandGPU.py
+cmsRun "${CMSSW_BASE}"/src/Validation/RecoParticleFlow/test/run_DQM_forGPU_HLT.py
+cmsRun "${CMSSW_BASE}"/src/Validation/RecoParticleFlow/test/run_HARVESTING_forGPU_HLT.py &> /dev/null

--- a/RecoParticleFlow/PFClusterProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/BuildFile.xml
@@ -15,6 +15,11 @@
 <use name="CalibCalorimetry/EcalTPGTools"/>
 <use name="DataFormats/HGCRecHit"/>
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
+<use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/CUDACore"/>
+<use name="HeterogeneousCore/CUDAUtilities"/>
+<use name="CUDADataFormats/Common"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="vdt_headers"/>
 <use name="rootmath"/>
 <use name="root"/>

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h
@@ -1,0 +1,84 @@
+#ifndef RecoParticleFlow_PFClusterProducer_PFClusteringParamsGPU_h
+#define RecoParticleFlow_PFClusterProducer_PFClusteringParamsGPU_h
+
+#include <vector>
+
+#include "FWCore/Utilities/interface/propagate_const.h"
+#include "FWCore/Utilities/interface/propagate_const_array.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+
+#include "CUDADataFormats/Common/interface/PortableDeviceCollection.h"
+#include "CUDADataFormats/Common/interface/PortableHostCollection.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+#ifndef __CUDACC__
+#include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
+#include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
+#endif
+
+namespace edm {
+  class ParameterSet;
+  class ParameterSetDescription;
+}
+
+class PFClusteringParamsGPU {
+public:
+  GENERATE_SOA_LAYOUT(ProductSoALayout,
+                      SOA_SCALAR(int32_t, nNeigh),
+                      SOA_SCALAR(float, seedPt2ThresholdEB),
+                      SOA_SCALAR(float, seedPt2ThresholdEE),
+                      SOA_COLUMN(float, seedEThresholdEB_vec),
+                      SOA_COLUMN(float, seedEThresholdEE_vec),
+                      SOA_COLUMN(float, topoEThresholdEB_vec),
+                      SOA_COLUMN(float, topoEThresholdEE_vec),
+                      SOA_SCALAR(float, showerSigma2),
+                      SOA_SCALAR(float, minFracToKeep),
+                      SOA_SCALAR(float, minFracTot),
+                      SOA_SCALAR(uint32_t, maxIterations),
+                      SOA_SCALAR(bool, excludeOtherSeeds),
+                      SOA_SCALAR(float, stoppingTolerance),
+                      SOA_SCALAR(float, minFracInCalc),
+                      SOA_SCALAR(float, minAllowedNormalization),
+                      SOA_COLUMN(float, recHitEnergyNormInvEB_vec),
+                      SOA_COLUMN(float, recHitEnergyNormInvEE_vec),
+                      SOA_SCALAR(float, barrelTimeResConsts_corrTermLowE),
+                      SOA_SCALAR(float, barrelTimeResConsts_threshLowE),
+                      SOA_SCALAR(float, barrelTimeResConsts_noiseTerm),
+                      SOA_SCALAR(float, barrelTimeResConsts_constantTermLowE2),
+                      SOA_SCALAR(float, barrelTimeResConsts_noiseTermLowE),
+                      SOA_SCALAR(float, barrelTimeResConsts_threshHighE),
+                      SOA_SCALAR(float, barrelTimeResConsts_constantTerm2),
+                      SOA_SCALAR(float, barrelTimeResConsts_resHighE2),
+                      SOA_SCALAR(float, endcapTimeResConsts_corrTermLowE),
+                      SOA_SCALAR(float, endcapTimeResConsts_threshLowE),
+                      SOA_SCALAR(float, endcapTimeResConsts_noiseTerm),
+                      SOA_SCALAR(float, endcapTimeResConsts_constantTermLowE2),
+                      SOA_SCALAR(float, endcapTimeResConsts_noiseTermLowE),
+                      SOA_SCALAR(float, endcapTimeResConsts_threshHighE),
+                      SOA_SCALAR(float, endcapTimeResConsts_constantTerm2),
+                      SOA_SCALAR(float, endcapTimeResConsts_resHighE2))
+
+  using HostProduct = cms::cuda::PortableHostCollection<ProductSoALayout<>>;
+  using DeviceProduct = cms::cuda::PortableDeviceCollection<ProductSoALayout<>>;
+
+#ifndef __CUDACC__
+  PFClusteringParamsGPU(edm::ParameterSet const&);
+  ~PFClusteringParamsGPU() = default;
+
+  static void fillDescription(edm::ParameterSetDescription& psetDesc);
+
+  DeviceProduct const& getProduct(cudaStream_t) const;
+
+private:
+  constexpr static uint32_t kMaxDepth_barrel = 4;
+  constexpr static uint32_t kMaxDepth_endcap = 7;
+
+  void setParameterValues(edm::ParameterSet const& iConfig);
+
+  HostProduct params_;
+  cms::cuda::ESProduct<DeviceProduct> product_;
+#endif
+};
+
+#endif // RecoParticleFlow_PFClusterProducer_PFClusteringParamsGPU_h

--- a/RecoParticleFlow/PFClusterProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/plugins/BuildFile.xml
@@ -1,4 +1,11 @@
-<library name="RecoParticleFlowPFClusterProducerPlugins" file="*.cc *.cu">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+
+<library name="RecoParticleFlowPFClusterProducerPlugins" file="*.cc ${cuda_src}">
   <use name="CondFormats/HcalObjects"/>
   <use name="CondFormats/EcalObjects"/>
   <use name="CondFormats/DataRecord"/>

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.h
@@ -5,13 +5,12 @@
 
 #include "CUDADataFormats/PFRecHitSoA/interface/PFRecHitCollection.h"
 
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
 #include "CudaPFCommon.h"
 #include "DeclsForKernels.h"
 
 namespace PFClusterCudaHCAL {
-
-  void initializeCudaConstants(const PFClustering::common::CudaHCALConstants& cudaConstants,
-                               const cudaStream_t cudaStream = cudaStreamDefault);
 
   void PFRechitToPFCluster_HCALV2(size_t size,
                                   const float* __restrict__ pfrh_x,
@@ -52,6 +51,7 @@ namespace PFClusterCudaHCAL {
 
   void PFRechitToPFCluster_HCAL_entryPoint(
       cudaStream_t cudaStream,
+      PFClusteringParamsGPU::DeviceProduct const& pfClusParams,
       int nEdges,
       ::hcal::PFRecHitCollection<::pf::common::DevStoragePolicy> const& inputPFRecHits,
       ::PFClustering::HCAL::OutputDataGPU& outputGPU,

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducerCudaHCAL.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducerCudaHCAL.cc
@@ -34,6 +34,9 @@
 #include "DeclsForKernels.h"
 #include "PFClusterCudaHCAL.h"
 
+#include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
 class PFClusterProducerCudaHCAL : public edm::stream::EDProducer<edm::ExternalWork> {
 public:
   PFClusterProducerCudaHCAL(const edm::ParameterSet&);
@@ -58,6 +61,8 @@ private:
 
   edm::EDGetTokenT<cms::cuda::Product<hcal::PFRecHitCollection<pf::common::DevStoragePolicy>>> InputPFRecHitSoA_Token_;
 
+  edm::ESGetToken<PFClusteringParamsGPU, JobConfigurationGPURecord> const pfClusParamsToken_;
+
   bool initCuda_ = true;
   int nRH_ = 0;
 
@@ -72,7 +77,6 @@ private:
   //cms::cuda::ContextState cudaState_;
 
   PFClustering::HCAL::ConfigurationParameters cudaConfig_;
-  PFClustering::common::CudaHCALConstants cudaConstants;
 
   PFClustering::HCAL::OutputDataCPU outputCPU;
   PFClustering::HCAL::OutputDataGPU outputGPU;
@@ -82,6 +86,7 @@ private:
 
 PFClusterProducerCudaHCAL::PFClusterProducerCudaHCAL(const edm::ParameterSet& conf)
     : InputPFRecHitSoA_Token_{consumes(conf.getParameter<edm::InputTag>("PFRecHitsLabelIn"))},
+      pfClusParamsToken_{esConsumes()},
       _produceSoA{conf.getParameter<bool>("produceSoA")},
       _produceLegacy{conf.getParameter<bool>("produceLegacy")},
       _rechitsLabel{consumes(conf.getParameter<edm::InputTag>("recHitsSource"))} {
@@ -101,9 +106,6 @@ PFClusterProducerCudaHCAL::PFClusterProducerCudaHCAL(const edm::ParameterSet& co
   _seedFinder = SeedFinderFactory::get()->create(sfName, sfConf);
 
   const edm::VParameterSet& seedFinderConfs = sfConf.getParameterSetVector("thresholdsByDetector");
-
-  cudaConstants.minFracInCalc = 0.0;
-  cudaConstants.minAllowedNormalization = 0.0;
 
   //setup topo cluster builder
   const edm::ParameterSet& initConf = conf.getParameterSet("initialClusteringStep");
@@ -125,8 +127,6 @@ PFClusterProducerCudaHCAL::PFClusterProducerCudaHCAL(const edm::ParameterSet& co
       const edm::ParameterSet& acConf = pfcConf.getParameterSet("positionCalc");
       const std::string& algoac = acConf.getParameter<std::string>("algoName");
       _positionCalc = PFCPositionCalculatorFactory::get()->create(algoac, acConf, cc);
-      cudaConstants.minFracInCalc = (float)acConf.getParameter<double>("minFractionInCalc");
-      cudaConstants.minAllowedNormalization = (float)acConf.getParameter<double>("minAllowedNormalization");
     }
 
     if (pfcConf.exists("allCellsPositionCalc")) {
@@ -147,103 +147,6 @@ PFClusterProducerCudaHCAL::PFClusterProducerCudaHCAL(const edm::ParameterSet& co
     const std::string& cName = cConf.getParameter<std::string>("algoName");
     _energyCorrector = PFClusterEnergyCorrectorFactory::get()->create(cName, cConf);
   }
-
-  cudaConstants.showerSigma2 = (float)std::pow(pfcConf.getParameter<double>("showerSigma"), 2.);
-  const auto& recHitEnergyNormConf = pfcConf.getParameterSetVector("recHitEnergyNorms");
-  for (const auto& pset : recHitEnergyNormConf) {
-    const std::string& det = pset.getParameter<std::string>("detector");
-    if (det == std::string("HCAL_BARREL1")) {
-      const auto& recHitENorms = pset.getParameter<std::vector<double>>("recHitEnergyNorm");
-      std::copy(recHitENorms.begin(), recHitENorms.end(), cudaConstants.recHitEnergyNormInvEB_vec);
-      for (auto& x : cudaConstants.recHitEnergyNormInvEB_vec)
-        x = std::pow(x, -1);  // Invert these values
-    } else if (det == std::string("HCAL_ENDCAP")) {
-      const auto& recHitENorms = pset.getParameter<std::vector<double>>("recHitEnergyNorm");
-      std::copy(recHitENorms.begin(), recHitENorms.end(), cudaConstants.recHitEnergyNormInvEE_vec);
-      for (auto& x : cudaConstants.recHitEnergyNormInvEE_vec)
-        x = std::pow(x, -1);  // Invert these values
-    } else
-      std::cout << "Unknown detector when parsing recHitEnergyNorm: " << det << std::endl;
-  }
-  //float recHitEnergyNormEB = 0.08;
-  //float recHitEnergyNormEE = 0.3;
-  //float minFracToKeep = 0.0000001;
-  cudaConstants.minFracToKeep = (float)pfcConf.getParameter<double>("minFractionToKeep");
-  cudaConstants.minFracTot = (float)pfcConf.getParameter<double>("minFracTot");
-
-  // Max PFClustering iterations
-  cudaConstants.maxIterations = pfcConf.getParameter<unsigned>("maxIterations");
-
-  cudaConstants.excludeOtherSeeds = pfcConf.getParameter<bool>("excludeOtherSeeds");
-
-  cudaConstants.stoppingTolerance = (float)pfcConf.getParameter<double>("stoppingTolerance");
-
-  cudaConstants.seedPt2ThresholdEB = -1;
-  cudaConstants.seedPt2ThresholdEE = -1;
-  for (const auto& pset : seedFinderConfs) {
-    const std::string& det = pset.getParameter<std::string>("detector");
-    if (det == std::string("HCAL_BARREL1")) {
-      const auto& thresholds = pset.getParameter<std::vector<double>>("seedingThreshold");
-      std::copy(thresholds.begin(), thresholds.end(), cudaConstants.seedEThresholdEB_vec);
-      cudaConstants.seedPt2ThresholdEB =
-          (float)std::pow(pset.getParameter<std::vector<double>>("seedingThresholdPt")[0], 2.0);
-
-    } else if (det == std::string("HCAL_ENDCAP")) {
-      const auto& thresholds = pset.getParameter<std::vector<double>>("seedingThreshold");
-      std::copy(thresholds.begin(), thresholds.end(), cudaConstants.seedEThresholdEE_vec);
-      cudaConstants.seedPt2ThresholdEE =
-          (float)std::pow(pset.getParameter<std::vector<double>>("seedingThresholdPt")[0], 2.0);
-    } else
-      std::cout << "Unknown detector when parsing seedFinder: " << det << std::endl;
-  }
-
-  const auto& topoThresholdConf = initConf.getParameterSetVector("thresholdsByDetector");
-  for (const auto& pset : topoThresholdConf) {
-    const std::string& det = pset.getParameter<std::string>("detector");
-    if (det == std::string("HCAL_BARREL1")) {
-      const auto& thresholds = pset.getParameter<std::vector<double>>("gatheringThreshold");
-      std::copy(thresholds.begin(), thresholds.end(), cudaConstants.topoEThresholdEB_vec);
-    } else if (det == std::string("HCAL_ENDCAP")) {
-      const auto& thresholds = pset.getParameter<std::vector<double>>("gatheringThreshold");
-      std::copy(thresholds.begin(), thresholds.end(), cudaConstants.topoEThresholdEE_vec);
-    } else
-      std::cout << "Unknown detector when parsing initClusteringStep: " << det << std::endl;
-  }
-
-  if (pfcConf.exists("timeResolutionCalcEndcap")) {
-    const edm::ParameterSet& endcapTimeResConf = pfcConf.getParameterSet("timeResolutionCalcEndcap");
-    cudaConstants.endcapTimeResConsts.corrTermLowE = (float)endcapTimeResConf.getParameter<double>("corrTermLowE");
-    cudaConstants.endcapTimeResConsts.threshLowE = (float)endcapTimeResConf.getParameter<double>("threshLowE");
-    cudaConstants.endcapTimeResConsts.noiseTerm = (float)endcapTimeResConf.getParameter<double>("noiseTerm");
-    cudaConstants.endcapTimeResConsts.constantTermLowE2 =
-        (float)std::pow(endcapTimeResConf.getParameter<double>("constantTermLowE"), 2.0);
-    cudaConstants.endcapTimeResConsts.noiseTermLowE = (float)endcapTimeResConf.getParameter<double>("noiseTermLowE");
-    cudaConstants.endcapTimeResConsts.threshHighE = (float)endcapTimeResConf.getParameter<double>("threshHighE");
-    cudaConstants.endcapTimeResConsts.constantTerm2 =
-        (float)std::pow(endcapTimeResConf.getParameter<double>("constantTerm"), 2.0);
-    cudaConstants.endcapTimeResConsts.resHighE2 =
-        (float)std::pow(cudaConstants.endcapTimeResConsts.noiseTerm / cudaConstants.endcapTimeResConsts.threshHighE,
-                        2.0) +
-        cudaConstants.endcapTimeResConsts.constantTerm2;
-  }
-
-  if (pfcConf.exists("timeResolutionCalcBarrel")) {
-    const edm::ParameterSet& barrelTimeResConf = pfcConf.getParameterSet("timeResolutionCalcBarrel");
-    cudaConstants.barrelTimeResConsts.corrTermLowE = (float)barrelTimeResConf.getParameter<double>("corrTermLowE");
-    cudaConstants.barrelTimeResConsts.threshLowE = (float)barrelTimeResConf.getParameter<double>("threshLowE");
-    cudaConstants.barrelTimeResConsts.noiseTerm = (float)barrelTimeResConf.getParameter<double>("noiseTerm");
-    cudaConstants.barrelTimeResConsts.constantTermLowE2 =
-        (float)std::pow(barrelTimeResConf.getParameter<double>("constantTermLowE"), 2.0);
-    cudaConstants.barrelTimeResConsts.noiseTermLowE = (float)barrelTimeResConf.getParameter<double>("noiseTermLowE");
-    cudaConstants.barrelTimeResConsts.threshHighE = (float)barrelTimeResConf.getParameter<double>("threshHighE");
-    cudaConstants.barrelTimeResConsts.constantTerm2 =
-        (float)std::pow(barrelTimeResConf.getParameter<double>("constantTerm"), 2.0);
-    cudaConstants.barrelTimeResConsts.resHighE2 =
-        (float)std::pow(cudaConstants.barrelTimeResConsts.noiseTerm / cudaConstants.barrelTimeResConsts.threshHighE,
-                        2.0) +
-        cudaConstants.barrelTimeResConsts.constantTerm2;
-  }
-  cudaConstants.nNeigh = sfConf.getParameter<int>("nNeighbours");
 
   produces<reco::PFClusterCollection>();
 }
@@ -282,8 +185,6 @@ void PFClusterProducerCudaHCAL::acquire(edm::Event const& event,
   auto cudaStream = ctx.stream();
 
   if (initCuda_) {
-    // Only allocate Cuda memory on first event
-    PFClusterCudaHCAL::initializeCudaConstants(cudaConstants, cudaStream);
 
     outputCPU.allocate(cudaConfig_, cudaStream);
     outputGPU.allocate(cudaConfig_, cudaStream);
@@ -306,9 +207,11 @@ void PFClusterProducerCudaHCAL::acquire(edm::Event const& event,
   // if (cudaStreamQuery(cudaStream) != cudaSuccess)
   //   cudaCheck(cudaStreamSynchronize(cudaStream));
 
+  auto const& pfClusParamsProduct = setup.getData(pfClusParamsToken_).getProduct(cudaStream);
+
   // Calling cuda kernels
   PFClusterCudaHCAL::PFRechitToPFCluster_HCAL_entryPoint(
-      cudaStream, totalNeighbours, PFRecHits, outputGPU, scratchGPU, kernelTimers);
+      cudaStream, pfClusParamsProduct, totalNeighbours, PFRecHits, outputGPU, scratchGPU, kernelTimers);
 
   if (!_produceLegacy)
     return;  // do device->host transfer only when we are producing Legacy data

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducerCudaHCAL.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducerCudaHCAL.cc
@@ -19,6 +19,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
@@ -86,7 +87,7 @@ private:
 
 PFClusterProducerCudaHCAL::PFClusterProducerCudaHCAL(const edm::ParameterSet& conf)
     : InputPFRecHitSoA_Token_{consumes(conf.getParameter<edm::InputTag>("PFRecHitsLabelIn"))},
-      pfClusParamsToken_{esConsumes()},
+      pfClusParamsToken_{esConsumes(conf.getParameter<edm::ESInputTag>("pfClusteringParameters"))},
       _produceSoA{conf.getParameter<bool>("produceSoA")},
       _produceLegacy{conf.getParameter<bool>("produceLegacy")},
       _rechitsLabel{consumes(conf.getParameter<edm::InputTag>("recHitsSource"))} {
@@ -159,6 +160,9 @@ void PFClusterProducerCudaHCAL::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("PFRecHitsLabelIn", edm::InputTag("hltParticleFlowRecHitHBHE"));
   desc.add<bool>("produceSoA", true);
   desc.add<bool>("produceLegacy", true);
+
+  desc.add<edm::ESInputTag>("pfClusteringParameters", edm::ESInputTag("pfClusteringParamsGPUESSource", "pfClusParamsOffline"));
+
   // Prevents the producer and navigator parameter sets from throwing an exception
   // TODO: Replace with a proper parameter set description: twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideConfigurationValidationAndHelp
   desc.setAllowAnything();

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusteringParamsGPUESSource.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusteringParamsGPUESSource.cc
@@ -1,3 +1,4 @@
+#include <string>
 #include <vector>
 #include <memory>
 
@@ -28,6 +29,7 @@ private:
 };
 
 PFClusteringParamsGPUESSource::PFClusteringParamsGPUESSource(edm::ParameterSet const& pset) : pset_{pset} {
+  // the fwk automatically uses "appendToDataLabel" as product label of the ESProduct
   setWhatProduced(this);
   findingRecord<JobConfigurationGPURecord>();
 }
@@ -40,6 +42,7 @@ void PFClusteringParamsGPUESSource::setIntervalFor(const edm::eventsetup::EventS
 
 void PFClusteringParamsGPUESSource::fillDescriptions(edm::ConfigurationDescriptions& desc) {
   edm::ParameterSetDescription psetDesc;
+  psetDesc.add<std::string>("appendToDataLabel", "pfClusParamsOffline");
   PFClusteringParamsGPU::fillDescription(psetDesc);
   desc.addWithDefaultLabel(psetDesc);
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusteringParamsGPUESSource.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusteringParamsGPUESSource.cc
@@ -1,0 +1,52 @@
+#include <vector>
+#include <memory>
+
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+class PFClusteringParamsGPUESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  PFClusteringParamsGPUESSource(edm::ParameterSet const&);
+  ~PFClusteringParamsGPUESSource() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  std::unique_ptr<PFClusteringParamsGPU> produce(JobConfigurationGPURecord const&);
+
+protected:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval&) override;
+
+private:
+  edm::ParameterSet const& pset_;
+};
+
+PFClusteringParamsGPUESSource::PFClusteringParamsGPUESSource(edm::ParameterSet const& pset) : pset_{pset} {
+  setWhatProduced(this);
+  findingRecord<JobConfigurationGPURecord>();
+}
+
+void PFClusteringParamsGPUESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey& iKey,
+                                                       const edm::IOVSyncValue& iTime,
+                                                       edm::ValidityInterval& oInterval) {
+  oInterval = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
+}
+
+void PFClusteringParamsGPUESSource::fillDescriptions(edm::ConfigurationDescriptions& desc) {
+  edm::ParameterSetDescription psetDesc;
+  PFClusteringParamsGPU::fillDescription(psetDesc);
+  desc.addWithDefaultLabel(psetDesc);
+}
+
+std::unique_ptr<PFClusteringParamsGPU> PFClusteringParamsGPUESSource::produce(JobConfigurationGPURecord const&) {
+  return std::make_unique<PFClusteringParamsGPU>(pset_);
+}
+
+#include "FWCore/Framework/interface/SourceFactory.h"
+DEFINE_FWK_EVENTSETUP_SOURCE(PFClusteringParamsGPUESSource);

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -87,18 +87,20 @@ phase2_timing.toModify(particleFlowClusterECAL,
                             inputECAL = 'particleFlowTimeAssignerECAL')
 
 #--- for Run 3 on GPU
+from Configuration.ProcessModifiers.gpu_cff import gpu
+
 from RecoParticleFlow.PFClusterProducer.pfhbheRecHitParamsGPUESProducer_cfi import pfhbheRecHitParamsGPUESProducer
 from RecoParticleFlow.PFClusterProducer.pfhbheTopologyGPUESProducer_cfi import pfhbheTopologyGPUESProducer
-from Configuration.ProcessModifiers.gpu_cff import gpu
-from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
+from RecoParticleFlow.PFClusterProducer.pfClusteringParamsGPUESSource_cfi import pfClusteringParamsGPUESSource
 
 _gpu_pfClusteringHBHEHFTask = pfClusteringHBHEHFTask.copy()
+_gpu_pfClusteringHBHEHFTask.add(pfhbheRecHitParamsGPUESProducer)
+_gpu_pfClusteringHBHEHFTask.add(pfhbheTopologyGPUESProducer)
+_gpu_pfClusteringHBHEHFTask.add(pfClusteringParamsGPUESSource)
+gpu.toReplaceWith(pfClusteringHBHEHFTask, _gpu_pfClusteringHBHEHFTask)
+
 _gpu_pfClusteringHBHEHFOnlyTask = pfClusteringHBHEHFOnlyTask.copy()
-_gpu_pfClusteringHBHEHFTask.add(cms.Task(pfhbheRecHitParamsGPUESProducer,pfhbheTopologyGPUESProducer))
-_gpu_pfClusteringHBHEHFOnlyTask.add(cms.Task(pfhbheRecHitParamsGPUESProducer,pfhbheTopologyGPUESProducer))
-
-gpu.toReplaceWith(pfClusteringHBHEHFTask,
-                                  _gpu_pfClusteringHBHEHFTask)
-gpu.toReplaceWith(pfClusteringHBHEHFOnlyTask,
-                                  _gpu_pfClusteringHBHEHFOnlyTask)
-
+_gpu_pfClusteringHBHEHFOnlyTask.add(pfhbheRecHitParamsGPUESProducer)
+_gpu_pfClusteringHBHEHFOnlyTask.add(pfhbheTopologyGPUESProducer)
+_gpu_pfClusteringHBHEHFOnlyTask.add(pfClusteringParamsGPUESSource)
+gpu.toReplaceWith(pfClusteringHBHEHFOnlyTask, _gpu_pfClusteringHBHEHFOnlyTask)

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusteringParamsGPU.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusteringParamsGPU.cc
@@ -1,0 +1,226 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+#include <cmath>
+
+PFClusteringParamsGPU::PFClusteringParamsGPU(edm::ParameterSet const& iConfig)
+ : params_(7) { setParameterValues(iConfig); }
+
+PFClusteringParamsGPU::DeviceProduct const& PFClusteringParamsGPU::getProduct(cudaStream_t cudaStream) const {
+  auto const& ret = product_.dataForCurrentDeviceAsync(
+      cudaStream, [this](DeviceProduct& product, cudaStream_t cudaStream) {
+        product = DeviceProduct(params_->metadata().size(), cudaStream);
+        cudaCheck(cudaMemcpyAsync(product.buffer().get(),
+                                  params_.const_buffer().get(),
+                                  params_.bufferSize(),
+                                  cudaMemcpyHostToDevice,
+                                  cudaStream));
+      });
+
+  return ret;
+}
+
+void PFClusteringParamsGPU::setParameterValues(edm::ParameterSet const& iConfig) {
+  auto view = params_.view();
+
+  // seedFinder
+  auto const& sfConf = iConfig.getParameterSet("seedFinder");
+  view.nNeigh() = sfConf.getParameter<int>("nNeighbours");
+  auto const& seedFinderConfs = sfConf.getParameterSetVector("thresholdsByDetector");
+  for (auto const& pset : seedFinderConfs) {
+    auto const& det = pset.getParameter<std::string>("detector");
+    auto seedPt2Threshold = std::pow(pset.getParameter<double>("seedingThresholdPt"), 2.);
+    auto const& thresholds = pset.getParameter<std::vector<double>>("seedingThreshold");
+    if (det == "HCAL_BARREL1") {
+      if (thresholds.size() != kMaxDepth_barrel)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_barrel << ") for \"\" vector of det = \"" << det << "\"";
+      view.seedPt2ThresholdEB() = seedPt2Threshold;
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.seedEThresholdEB_vec()[idx] = thresholds[idx];
+      }
+    } else if (det == "HCAL_ENDCAP") {
+      if (thresholds.size() != kMaxDepth_endcap)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_endcap << ") for \"\" vector of det = \"" << det << "\"";
+      view.seedPt2ThresholdEE() = seedPt2Threshold;
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.seedEThresholdEE_vec()[idx] = thresholds[idx];
+      }
+    } else {
+      throw cms::Exception("InvalidConfiguration") << "Unknown detector when parsing seedFinder: " << det;
+    }
+  }
+
+  // initialClusteringStep
+  auto const& initConf = iConfig.getParameterSet("initialClusteringStep");
+  auto const& topoThresholdConf = initConf.getParameterSetVector("thresholdsByDetector");
+  for (auto const& pset : topoThresholdConf) {
+    auto const& det = pset.getParameter<std::string>("detector");
+    auto const& thresholds = pset.getParameter<std::vector<double>>("gatheringThreshold");
+    if (det == "HCAL_BARREL1") {
+      if (thresholds.size() != kMaxDepth_barrel)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_barrel << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.topoEThresholdEB_vec()[idx] = thresholds[idx];
+      }
+    } else if (det == "HCAL_ENDCAP") {
+      if (thresholds.size() != kMaxDepth_endcap)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_endcap << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < thresholds.size(); ++idx) {
+        view.topoEThresholdEE_vec()[idx] = thresholds[idx];
+      }
+    } else {
+      throw cms::Exception("InvalidConfiguration") << "Unknown detector when parsing initClusteringStep: " << det;
+    }
+  }
+
+  // pfClusterBuilder
+  auto const & pfClusterPSet = iConfig.getParameterSet("pfClusterBuilder");
+  view.showerSigma2() = std::pow(pfClusterPSet.getParameter<double>("showerSigma"), 2.);
+  view.minFracToKeep() = pfClusterPSet.getParameter<double>("minFractionToKeep");
+  view.minFracTot() = pfClusterPSet.getParameter<double>("minFracTot");
+  view.maxIterations() = pfClusterPSet.getParameter<unsigned int>("maxIterations");
+  view.excludeOtherSeeds() = pfClusterPSet.getParameter<bool>("excludeOtherSeeds");
+  view.stoppingTolerance() = pfClusterPSet.getParameter<double>("stoppingTolerance");
+  auto const& pcPSet = pfClusterPSet.getParameterSet("positionCalc");
+  view.minFracInCalc() = pcPSet.getParameter<double>("minFractionInCalc");
+  view.minAllowedNormalization() = pcPSet.getParameter<double>("minAllowedNormalization");
+
+  auto const& recHitEnergyNormConf = pfClusterPSet.getParameterSetVector("recHitEnergyNorms");
+  for (auto const& pset : recHitEnergyNormConf) {
+    auto const& recHitNorms = pset.getParameter<std::vector<double>>("recHitEnergyNorm");
+    auto const& det = pset.getParameter<std::string>("detector");
+    if (det == "HCAL_BARREL1") {
+      if (recHitNorms.size() != kMaxDepth_barrel)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << recHitNorms.size() << " != " << kMaxDepth_barrel << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < recHitNorms.size(); ++idx) {
+        view.recHitEnergyNormInvEB_vec()[idx] = 1. / recHitNorms[idx];
+      }
+    } else if (det == "HCAL_ENDCAP") {
+      if (recHitNorms.size() != kMaxDepth_endcap)
+        throw cms::Exception("InvalidConfiguration") << "Invalid size (" << recHitNorms.size() << " != " << kMaxDepth_endcap << ") for \"\" vector of det = \"" << det << "\"";
+      for (size_t idx = 0; idx < recHitNorms.size(); ++idx) {
+        view.recHitEnergyNormInvEE_vec()[idx] = 1. / recHitNorms[idx];
+      }
+    } else {
+      throw cms::Exception("InvalidConfiguration") << "Unknown detector when parsing recHitEnergyNorms: " << det;
+    }
+  }
+
+  auto const& barrelTimeResConf = pfClusterPSet.getParameterSet("timeResolutionCalcBarrel");
+  view.barrelTimeResConsts_corrTermLowE() = barrelTimeResConf.getParameter<double>("corrTermLowE");
+  view.barrelTimeResConsts_threshLowE() = barrelTimeResConf.getParameter<double>("threshLowE");
+  view.barrelTimeResConsts_noiseTerm() = barrelTimeResConf.getParameter<double>("noiseTerm");
+  view.barrelTimeResConsts_constantTermLowE2() = std::pow(barrelTimeResConf.getParameter<double>("constantTermLowE"), 2.);
+  view.barrelTimeResConsts_noiseTermLowE() = barrelTimeResConf.getParameter<double>("noiseTermLowE");
+  view.barrelTimeResConsts_threshHighE() = barrelTimeResConf.getParameter<double>("threshHighE");
+  view.barrelTimeResConsts_constantTerm2() = std::pow(barrelTimeResConf.getParameter<double>("constantTerm"), 2.);
+  view.barrelTimeResConsts_resHighE2() = std::pow(view.barrelTimeResConsts_noiseTerm() / view.barrelTimeResConsts_threshHighE(), 2.)
+    + view.barrelTimeResConsts_constantTerm2();
+
+  auto const& endcapTimeResConf = pfClusterPSet.getParameterSet("timeResolutionCalcEndcap");
+  view.endcapTimeResConsts_corrTermLowE() = endcapTimeResConf.getParameter<double>("corrTermLowE");
+  view.endcapTimeResConsts_threshLowE() = endcapTimeResConf.getParameter<double>("threshLowE");
+  view.endcapTimeResConsts_noiseTerm() = endcapTimeResConf.getParameter<double>("noiseTerm");
+  view.endcapTimeResConsts_constantTermLowE2() = std::pow(endcapTimeResConf.getParameter<double>("constantTermLowE"), 2.);
+  view.endcapTimeResConsts_noiseTermLowE() = endcapTimeResConf.getParameter<double>("noiseTermLowE");
+  view.endcapTimeResConsts_threshHighE() = endcapTimeResConf.getParameter<double>("threshHighE");
+  view.endcapTimeResConsts_constantTerm2() = std::pow(endcapTimeResConf.getParameter<double>("constantTerm"), 2.);
+  view.endcapTimeResConsts_resHighE2() = std::pow(view.endcapTimeResConsts_noiseTerm() / view.endcapTimeResConsts_threshHighE(), 2.)
+    + view.endcapTimeResConsts_constantTerm2();
+}
+
+void PFClusteringParamsGPU::fillDescription(edm::ParameterSetDescription& desc) {
+  {
+    auto const psetName = "seedFinder";
+    edm::ParameterSetDescription foo;
+    foo.add<int>("nNeighbours", 4);
+    {
+      edm::ParameterSetDescription validator;
+      validator.add<std::string>("detector", "");
+      validator.add<std::vector<double>>("seedingThreshold", {});
+      validator.add<double>("seedingThresholdPt", 0.);
+      std::vector<edm::ParameterSet> vDefaults(2);
+      vDefaults[0].addParameter<std::string>("detector", "HCAL_BARREL1");
+      vDefaults[0].addParameter<std::vector<double>>("seedingThreshold", {0.125, 0.25, 0.35, 0.35});
+      vDefaults[0].addParameter<double>("seedingThresholdPt", 0.);
+      vDefaults[1].addParameter<std::string>("detector", "HCAL_ENDCAP");
+      vDefaults[1].addParameter<std::vector<double>>("seedingThreshold", {0.1375, 0.275, 0.275, 0.275, 0.275, 0.275, 0.275});
+      vDefaults[1].addParameter<double>("seedingThresholdPt", 0.);
+      foo.addVPSet("thresholdsByDetector", validator, vDefaults);
+    }
+    desc.add(psetName, foo);
+  }
+  {
+    auto const psetName = "initialClusteringStep";
+    edm::ParameterSetDescription foo;
+    {
+      edm::ParameterSetDescription validator;
+      validator.add<std::string>("detector", "");
+      validator.add<std::vector<double>>("gatheringThreshold", {});
+      std::vector<edm::ParameterSet> vDefaults(2);
+      vDefaults[0].addParameter<std::string>("detector", "HCAL_BARREL1");
+      vDefaults[0].addParameter<std::vector<double>>("gatheringThreshold", {0.1, 0.2, 0.3, 0.3});
+      vDefaults[1].addParameter<std::string>("detector", "HCAL_ENDCAP");
+      vDefaults[1].addParameter<std::vector<double>>("gatheringThreshold", {0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2});
+      foo.addVPSet("thresholdsByDetector", validator, vDefaults);
+    }
+    desc.add(psetName, foo);
+  }
+  {
+    auto const psetName = "pfClusterBuilder";
+    edm::ParameterSetDescription foo;
+    foo.add<unsigned int>("maxIterations", 50);
+    foo.add<double>("minFracTot", 1e-20);
+    foo.add<double>("minFractionToKeep", 1e-7);
+    foo.add<bool>("excludeOtherSeeds", true);
+    foo.add<double>("showerSigma", 10.);
+    foo.add<double>("stoppingTolerance", 1e-8);
+    {
+      edm::ParameterSetDescription validator;
+      validator.add<std::string>("detector", "");
+      validator.add<std::vector<double>>("recHitEnergyNorm", {});
+      std::vector<edm::ParameterSet> vDefaults(2);
+      vDefaults[0].addParameter<std::string>("detector", "HCAL_BARREL1");
+      vDefaults[0].addParameter<std::vector<double>>("recHitEnergyNorm", {0.1, 0.2, 0.3, 0.3});
+      vDefaults[1].addParameter<std::string>("detector", "HCAL_ENDCAP");
+      vDefaults[1].addParameter<std::vector<double>>("recHitEnergyNorm", {0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2});
+      foo.addVPSet("recHitEnergyNorms", validator, vDefaults);
+    }
+    {
+      edm::ParameterSetDescription bar;
+      bar.add<double>("minFractionInCalc", 1e-9);
+      bar.add<double>("minAllowedNormalization", 1e-9);
+      foo.add("positionCalc", bar);
+    }
+    {
+      edm::ParameterSetDescription bar;
+      bar.add<double>("corrTermLowE", 0.);
+      bar.add<double>("threshLowE", 6.);
+      bar.add<double>("noiseTerm", 21.86);
+      bar.add<double>("constantTermLowE", 4.24);
+      bar.add<double>("noiseTermLowE", 8.);
+      bar.add<double>("threshHighE", 15.);
+      bar.add<double>("constantTerm", 2.82);
+      foo.add("timeResolutionCalcBarrel", bar);
+    }
+    {
+      edm::ParameterSetDescription bar;
+      bar.add<double>("corrTermLowE", 0.);
+      bar.add<double>("threshLowE", 6.);
+      bar.add<double>("noiseTerm", 21.86);
+      bar.add<double>("constantTermLowE", 4.24);
+      bar.add<double>("noiseTermLowE", 8.);
+      bar.add<double>("threshHighE", 15.);
+      bar.add<double>("constantTerm", 2.82);
+      foo.add("timeResolutionCalcEndcap", bar);
+    }
+    desc.add(psetName, foo);
+  }
+}
+
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(PFClusteringParamsGPU);

--- a/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
@@ -17,3 +17,19 @@
   <use name="root"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+
+<library name="TestDumpPFClusteringParamsGPU" file="TestDumpPFClusteringParamsGPU.cc ${cuda_src}">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <use name="RecoParticleFlow/PFClusterProducer"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoParticleFlow/PFClusterProducer/test/TestDumpPFClusteringParamsGPU.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/TestDumpPFClusteringParamsGPU.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
 #include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
@@ -26,12 +27,13 @@ private:
   cms::cuda::ContextState cudaState_;
 };
 
-TestDumpPFClusteringParamsGPU::TestDumpPFClusteringParamsGPU(edm::ParameterSet const& ps)
-    : pfClusParamsToken_{esConsumes()} {
+TestDumpPFClusteringParamsGPU::TestDumpPFClusteringParamsGPU(edm::ParameterSet const& iConfig)
+    : pfClusParamsToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("pfClusteringParameters"))} {
 }
 
 void TestDumpPFClusteringParamsGPU::fillDescriptions(edm::ConfigurationDescriptions& desc) {
   edm::ParameterSetDescription psetDesc;
+  psetDesc.add<edm::ESInputTag>("pfClusteringParameters", edm::ESInputTag("pfClusteringParamsGPUESSource", "pfClusParamsOffline"));
   desc.addWithDefaultLabel(psetDesc);
 }
 

--- a/RecoParticleFlow/PFClusterProducer/test/TestDumpPFClusteringParamsGPU.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/TestDumpPFClusteringParamsGPU.cc
@@ -1,0 +1,51 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
+#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+#include "testKernels.h"
+
+class TestDumpPFClusteringParamsGPU : public edm::stream::EDProducer<edm::ExternalWork> {
+public:
+  explicit TestDumpPFClusteringParamsGPU(edm::ParameterSet const&);
+  ~TestDumpPFClusteringParamsGPU() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void acquire(edm::Event const&, edm::EventSetup const&, edm::WaitingTaskWithArenaHolder) override;
+  void produce(edm::Event&, edm::EventSetup const&) override;
+
+  edm::ESGetToken<PFClusteringParamsGPU, JobConfigurationGPURecord> const pfClusParamsToken_;
+
+  cms::cuda::ContextState cudaState_;
+};
+
+TestDumpPFClusteringParamsGPU::TestDumpPFClusteringParamsGPU(edm::ParameterSet const& ps)
+    : pfClusParamsToken_{esConsumes()} {
+}
+
+void TestDumpPFClusteringParamsGPU::fillDescriptions(edm::ConfigurationDescriptions& desc) {
+  edm::ParameterSetDescription psetDesc;
+  desc.addWithDefaultLabel(psetDesc);
+}
+
+void TestDumpPFClusteringParamsGPU::acquire(edm::Event const& event,
+                             edm::EventSetup const& setup,
+                             edm::WaitingTaskWithArenaHolder holder) {
+  cms::cuda::ScopedContextAcquire ctx{event.streamID(), std::move(holder), cudaState_};
+  auto const& pfClusParamsProduct = setup.getData(pfClusParamsToken_).getProduct(ctx.stream());
+  testPFlow::testPFClusteringParamsEntryPoint(pfClusParamsProduct, ctx.stream());
+}
+
+void TestDumpPFClusteringParamsGPU::produce(edm::Event& event, edm::EventSetup const& setup) {
+  cms::cuda::ScopedContextProduce ctx{cudaState_};
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TestDumpPFClusteringParamsGPU);

--- a/RecoParticleFlow/PFClusterProducer/test/testKernels.cu
+++ b/RecoParticleFlow/PFClusterProducer/test/testKernels.cu
@@ -1,0 +1,69 @@
+#include <cuda_runtime.h>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+#include "testKernels.h"
+
+namespace testPFlowCUDA {
+
+  __global__ void printPFClusteringParamsOnGPU(PFClusteringParamsGPU::DeviceProduct::ConstView params){
+
+    printf("nNeigh: %d\n", params.nNeigh());
+    printf("seedPt2ThresholdEB: %4.2f\n", params.seedPt2ThresholdEB());
+    printf("seedPt2ThresholdEE: %4.2f\n", params.seedPt2ThresholdEE());
+
+    for (uint32_t idx = 0; idx < 4; ++idx)
+      printf("seedEThresholdEB_vec[%d]: %4.2f\n", idx, params.seedEThresholdEB_vec()[idx]);
+    for (uint32_t idx = 0; idx < 7; ++idx)
+      printf("seedEThresholdEE_vec[%d]: %4.2f\n", idx, params.seedEThresholdEE_vec()[idx]);
+
+    for (uint32_t idx = 0; idx < 4; ++idx)
+      printf("topoEThresholdEB_vec[%d]: %4.2f\n", idx, params.topoEThresholdEB_vec()[idx]);
+    for (uint32_t idx = 0; idx < 7; ++idx)
+      printf("topoEThresholdEE_vec[%d]: %4.2f\n", idx, params.topoEThresholdEE_vec()[idx]);
+
+    printf("showerSigma2: %4.2f\n", params.showerSigma2());
+    printf("minFracToKeep: %4.2f\n", params.minFracToKeep());
+    printf("minFracTot: %4.2f\n", params.minFracTot());
+    printf("maxIterations: %d\n", params.maxIterations());
+    printf("excludeOtherSeeds: %d\n", params.excludeOtherSeeds());
+    printf("stoppingTolerance: %4.2f\n", params.stoppingTolerance());
+    printf("minFracInCalc: %4.2f\n", params.minFracInCalc());
+    printf("minAllowedNormalization: %4.2f\n", params.minAllowedNormalization());
+
+    for (uint32_t idx = 0; idx < 4; ++idx)
+      printf("recHitEnergyNormInvEB_vec[%d]: %4.2f\n", idx, params.recHitEnergyNormInvEB_vec()[idx]);
+    for (uint32_t idx = 0; idx < 7; ++idx)
+      printf("recHitEnergyNormInvEE_vec[%d]: %4.2f\n", idx, params.recHitEnergyNormInvEE_vec()[idx]);
+
+    printf("barrelTimeResConsts_corrTermLowE: %4.2f\n", params.barrelTimeResConsts_corrTermLowE());
+    printf("barrelTimeResConsts_threshLowE: %4.2f\n", params.barrelTimeResConsts_threshLowE());
+    printf("barrelTimeResConsts_noiseTerm: %4.2f\n", params.barrelTimeResConsts_noiseTerm());
+    printf("barrelTimeResConsts_constantTermLowE2: %4.2f\n", params.barrelTimeResConsts_constantTermLowE2());
+    printf("barrelTimeResConsts_noiseTermLowE: %4.2f\n", params.barrelTimeResConsts_noiseTermLowE());
+    printf("barrelTimeResConsts_threshHighE: %4.2f\n", params.barrelTimeResConsts_threshHighE());
+    printf("barrelTimeResConsts_constantTerm2: %4.2f\n", params.barrelTimeResConsts_constantTerm2());
+    printf("barrelTimeResConsts_resHighE2: %4.2f\n", params.barrelTimeResConsts_resHighE2());
+
+    printf("endcapTimeResConsts_corrTermLowE: %4.2f\n", params.endcapTimeResConsts_corrTermLowE());
+    printf("endcapTimeResConsts_threshLowE: %4.2f\n", params.endcapTimeResConsts_threshLowE());
+    printf("endcapTimeResConsts_noiseTerm: %4.2f\n", params.endcapTimeResConsts_noiseTerm());
+    printf("endcapTimeResConsts_constantTermLowE2: %4.2f\n", params.endcapTimeResConsts_constantTermLowE2());
+    printf("endcapTimeResConsts_noiseTermLowE: %4.2f\n", params.endcapTimeResConsts_noiseTermLowE());
+    printf("endcapTimeResConsts_threshHighE: %4.2f\n", params.endcapTimeResConsts_threshHighE());
+    printf("endcapTimeResConsts_constantTerm2: %4.2f\n", params.endcapTimeResConsts_constantTerm2());
+    printf("endcapTimeResConsts_resHighE2: %4.2f\n", params.endcapTimeResConsts_resHighE2());
+  }
+
+}
+
+namespace testPFlow {
+
+  void testPFClusteringParamsEntryPoint(
+    PFClusteringParamsGPU::DeviceProduct const& pfClusParams,
+    cudaStream_t cudaStream
+  ) {
+    testPFlowCUDA::printPFClusteringParamsOnGPU<<<1, 1, 0, cudaStream>>>(pfClusParams.const_view());
+  }
+
+}

--- a/RecoParticleFlow/PFClusterProducer/test/testKernels.h
+++ b/RecoParticleFlow/PFClusterProducer/test/testKernels.h
@@ -1,0 +1,15 @@
+#ifndef RecoParticleFlow_PFClusterProducer_test_testKernels_h
+#define RecoParticleFlow_PFClusterProducer_test_testKernels_h
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFClusteringParamsGPU.h"
+
+namespace testPFlow {
+
+  void testPFClusteringParamsEntryPoint(
+    PFClusteringParamsGPU::DeviceProduct const& pfClusParams,
+    cudaStream_t cudaStream
+  );
+
+}
+
+#endif  // RecoParticleFlow_PFClusterProducer_test_testKernels_h

--- a/RecoParticleFlow/PFClusterProducer/test/testPFClusParamsGPU_cfg.py
+++ b/RecoParticleFlow/PFClusterProducer/test/testPFClusParamsGPU_cfg.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+###
+### EDM Input and job configuration
+###
+process.source = cms.Source("EmptySource")
+
+# limit the number of events to be processed
+process.maxEvents.input = 50
+
+# enable TrigReport, TimeReport and MultiThreading
+process.options.wantSummary = True
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 0
+
+###
+### ESModules, EDModules, Sequences, Tasks, Paths, EndPaths and Schedule
+###
+process.load("Configuration.StandardSequences.Accelerators_cff")
+
+from RecoParticleFlow.PFClusterProducer.pfClusteringParamsGPUESSource_cfi import pfClusteringParamsGPUESSource as _pfClusteringParamsGPUESSource
+process.PFClusteringParamsGPUESSource = _pfClusteringParamsGPUESSource.clone()
+
+process.theProducer = cms.EDProducer("TestDumpPFClusteringParamsGPU")
+
+process.theSequence = cms.Sequence( process.theProducer )
+
+process.thePath = cms.Path( process.theSequence )
+
+process.schedule = cms.Schedule( process.thePath )

--- a/RecoParticleFlow/PFClusterProducer/test/testPFClusParamsGPU_cfg.py
+++ b/RecoParticleFlow/PFClusterProducer/test/testPFClusParamsGPU_cfg.py
@@ -1,11 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("TEST")
+process = cms.Process('TEST')
 
 ###
 ### EDM Input and job configuration
 ###
-process.source = cms.Source("EmptySource")
+process.source = cms.Source('EmptySource')
 
 # limit the number of events to be processed
 process.maxEvents.input = 50
@@ -18,12 +18,17 @@ process.options.numberOfStreams = 0
 ###
 ### ESModules, EDModules, Sequences, Tasks, Paths, EndPaths and Schedule
 ###
-process.load("Configuration.StandardSequences.Accelerators_cff")
+process.load('Configuration.StandardSequences.Accelerators_cff')
 
 from RecoParticleFlow.PFClusterProducer.pfClusteringParamsGPUESSource_cfi import pfClusteringParamsGPUESSource as _pfClusteringParamsGPUESSource
-process.PFClusteringParamsGPUESSource = _pfClusteringParamsGPUESSource.clone()
+process.PFClusteringParamsGPUESSource = _pfClusteringParamsGPUESSource.clone(
+  appendToDataLabel = 'pfClusParamsOfflineDefault',
+)
 
-process.theProducer = cms.EDProducer("TestDumpPFClusteringParamsGPU")
+from RecoParticleFlow.PFClusterProducer.testDumpPFClusteringParamsGPU_cfi import testDumpPFClusteringParamsGPU as _testDumpPFClusteringParamsGPU
+process.theProducer = _testDumpPFClusteringParamsGPU.clone(
+  pfClusteringParameters = 'PFClusteringParamsGPUESSource:pfClusParamsOfflineDefault',
+)
 
 process.theSequence = cms.Sequence( process.theProducer )
 


### PR DESCRIPTION
This PR includes
 - the forward-port of https://github.com/jsamudio/cmssw/pull/6
 - the update of the PFCluster producer (and related kernels) the use the clustering parameters as taken from the EventSetup via the `ESSource` introduced in https://github.com/jsamudio/cmssw/pull/6

All these changes are merely technical.
 - Did a basic check of physics performance (CPU vs GPU) with the usual cfg files in `RecoParticleFlow/Configuration/test/`, and seen the usual level of agreement. Wrapped this simple test in a single script (to be kept for now for convenience), see `RecoParticleFlow/Configuration/test/testPFOnGPUvsCPU_HBHE.sh`.
 - Did not check throughput after these changes.
