### PR TITLE
fix to test cfg `testPFRecHitHBHETestProducers_cfg.py`

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitHBHEParamsESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitHBHEParamsESProducer.cc
@@ -10,22 +10,15 @@
 #include "RecoParticleFlow/PFRecHitProducer/interface/JobConfigurationAlpakaRecord.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitHBHEParamsAlpakaESData.h"
 
+#include <array>
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class PFRecHitHBHEParamsESProducer : public ESProducer {
   public:
     PFRecHitHBHEParamsESProducer(edm::ParameterSet const& iConfig) :
-        energyThresholdsHB_(iConfig.getParameter<std::vector<double>>("energyThresholdsHB")),
-        energyThresholdsHE_(iConfig.getParameter<std::vector<double>>("energyThresholdsHE")) {
-
-      if (energyThresholdsHB_.size() != kMaxDepthHB) {
-        throw cms::Exception("InvalidConfiguration") << "\"energyThresholdsHB\" must be a cms.vdouble() of size " << kMaxDepthHB;
-      }
-
-      if (energyThresholdsHE_.size() != kMaxDepthHE) {
-        throw cms::Exception("InvalidConfiguration") << "\"energyThresholdsHE\" must be a cms.vdouble() of size " << kMaxDepthHE;
-      }
-
+        energyThresholdsHB_(iConfig.getParameter<std::array<double, kMaxDepthHB>>("energyThresholdsHB")),
+        energyThresholdsHE_(iConfig.getParameter<std::array<double, kMaxDepthHE>>("energyThresholdsHE")) {
       setWhatProduced(this);
     }
 
@@ -52,8 +45,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     constexpr static uint8_t kMaxDepthHB = 4;
     constexpr static uint8_t kMaxDepthHE = 7;
 
-    std::vector<double> energyThresholdsHB_;
-    std::vector<double> energyThresholdsHE_;
+    std::array<double, kMaxDepthHB> energyThresholdsHB_;
+    std::array<double, kMaxDepthHE> energyThresholdsHE_;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoParticleFlow/PFRecHitProducer/test/testPFRecHitHBHETestProducers_cfg.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/testPFRecHitHBHETestProducers_cfg.py
@@ -23,8 +23,8 @@ parser.add_argument('-r', '--run', type=int, default=361054,
 parser.add_argument('-d', '--dumpPython', type=str, default=None,
                     help='Path to file containing output of process.dumpPython() (disabled by default)')
 
-parser.add_argument('-v', '--logVerbosityLevel', type=str, default='WARNING',
-                    help='Value of process.MessageLogger.cerr.threshold (examples: "INFO", "DEBUG") (default: "WARNING")')
+parser.add_argument('-v', '--logVerbosityLevel', type=str, default='FWKINFO',
+                    help='Value of process.MessageLogger.cerr.threshold (default: "FWKINFO"; examples: "INFO", "DEBUG")')
 
 argv = sys.argv[:]
 if '--' in argv: argv.remove('--')
@@ -73,7 +73,9 @@ process.pfRecHitHBHETopologyAlpakaESRcdESSource = cms.ESSource('EmptyESSource',
 
 from RecoParticleFlow.PFRecHitProducer.pfRecHitHBHEParamsESProducer_cfi import pfRecHitHBHEParamsESProducer as _pfRecHitHBHEParamsESProducer
 process.pfRecHitHBHEParamsESProducer = _pfRecHitHBHEParamsESProducer.clone(
-  appendToDataLabel = args.esProductLabel
+  appendToDataLabel = args.esProductLabel,
+  energyThresholdsHB = [0.1, 0.2, 0.3, 0.4],
+  energyThresholdsHE = [0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1],
 )
 
 from RecoParticleFlow.PFRecHitProducer.pfRecHitHBHETopologyESProducer_cfi import pfRecHitHBHETopologyESProducer as _pfRecHitHBHETopologyESProducer
@@ -119,17 +121,16 @@ process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 1 # only report every Nth event start
 process.MessageLogger.cerr.FwkReport.limit = -1      # max number of reported messages (all if -1)
 process.MessageLogger.cerr.enableStatistics = False  # enable "MessageLogger Summary" message
-process.MessageLogger.cerr.threshold = args.logLevel
-setattr(process.MessageLogger.cerr, args.logLevel,
+process.MessageLogger.cerr.threshold = args.logVerbosityLevel
+setattr(process.MessageLogger.cerr, args.logVerbosityLevel,
   cms.untracked.PSet(
     reportEvery = cms.untracked.int32(1), # every event!
     limit = cms.untracked.int32(-1)       # no limit! (default is limit=0, i.e. no messages reported)
   )
 )
-if args.logLevel == 'DEBUG':
+if args.logVerbosityLevel == 'DEBUG':
   process.MessageLogger.debugModules = ['*']
 
->>>>>>> jsamudio/PFRecHitAndCluster_GPU_13_0_0_pre4_stable
 # dump content of cms.Process to python file
 if args.dumpPython != None:
   open(args.dumpPython, 'w').write(process.dumpPython())


### PR DESCRIPTION
 - Fixes a bug introduced in https://github.com/jsamudio/cmssw/pull/11 in the test cfg `RecoParticleFlow/PFRecHitProducer/test/testPFRecHitHBHETestProducers_cfg.py`.
 - Switches to using `std::array` to enforce size check on parameters of `PFRecHitHBHEParamsESProducer`
