### PR TITLE
Fix PFRecHit validation; add Alpaka PFRecHit to legacy format conversion; performance optimisations

### DIFF
--- a/DataFormats/ParticleFlowReco_Alpaka/interface/PFRecHitSoA.h
+++ b/DataFormats/ParticleFlowReco_Alpaka/interface/PFRecHitSoA.h
@@ -12,19 +12,18 @@
 
 namespace reco {
   
-  using PFRecHitsNeighbours = Eigen::Matrix<uint32_t, 8, 1>;
+  using PFRecHitsNeighbours = Eigen::Matrix<int32_t, 8, 1>;
   GENERATE_SOA_LAYOUT(PFRecHitSoALayout,
     SOA_COLUMN(uint32_t, detId),
     SOA_COLUMN(float, energy),
     SOA_COLUMN(float, time),
     SOA_COLUMN(int, depth),
     SOA_COLUMN(PFLayer::Layer, layer),
-    SOA_COLUMN(uint32_t, num_neighbours),
-    SOA_EIGEN_COLUMN(PFRecHitsNeighbours, neighbours),
+    SOA_EIGEN_COLUMN(PFRecHitsNeighbours, neighbours),  // Neighbour indices (or -1); order: N, S, E, W, NE, SW, SE, NW
     SOA_COLUMN(float, x),
     SOA_COLUMN(float, y),
     SOA_COLUMN(float, z),
-    SOA_SCALAR(uint32_t, size)
+    SOA_SCALAR(uint32_t, size)  // Number of PFRecHits in SoA
   )
 
   using PFRecHitSoA = PFRecHitSoALayout<>;

--- a/RecoParticleFlow/Configuration/test/run_HBHEandPF_onCPUandGPU.py
+++ b/RecoParticleFlow/Configuration/test/run_HBHEandPF_onCPUandGPU.py
@@ -30,7 +30,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_12_4_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_124X_mcRun3_2022_realistic_v5-v1/10000/012eda92-aad5-4a95-8dbd-c79546b5f508.root'),
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/05ad6501-815f-4df6-b115-03ad028f9b76.root'),
     secondaryFileNames = cms.untracked.vstring()
 )
 

--- a/RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitProducerKernel.h
+++ b/RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitProducerKernel.h
@@ -20,8 +20,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       PFRecHitDeviceCollection& collection);
 
   private:
-    PFRecHitProducerKernel(cms::alpakatools::device_buffer<Device, uint32_t[]>&&);
+    PFRecHitProducerKernel(cms::alpakatools::device_buffer<Device, uint32_t[]>&&,
+      cms::alpakatools::device_buffer<Device, uint32_t>&&);
     cms::alpakatools::device_buffer<Device, uint32_t[]> denseId2pfRecHit;
+    cms::alpakatools::device_buffer<Device, uint32_t> num_pfRecHits;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoParticleFlow/PFRecHitProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/BuildFile.xml
@@ -9,6 +9,8 @@
   <use name="DataFormats/ParticleFlowReco_Alpaka"/>
   <use name="CommonTools/ParticleFlow"/>
   <use name="DQMServices/Core"/>
+  <use name="Geometry/CaloGeometry"/>
+  <use name="Geometry/Records"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
@@ -1,0 +1,81 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "DataFormats/ParticleFlowReco_Alpaka/interface/PFRecHitHostCollection.h"
+
+
+class LegacyPFRecHitProducer : public edm::stream::EDProducer<> {
+public:
+  LegacyPFRecHitProducer(edm::ParameterSet const& config) :
+    alpakaPfRecHitsToken(consumes(config.getParameter<edm::InputTag>("src"))),
+    legacyPfRecHitsToken(produces()),
+    geomToken(esConsumes<edm::Transition::BeginRun>())
+  {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  const edm::EDGetTokenT<reco::PFRecHitHostCollection> alpakaPfRecHitsToken;
+  const edm::EDPutTokenT<reco::PFRecHitCollection> legacyPfRecHitsToken;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken;
+  edm::ESHandle<CaloGeometry> geoHandle;
+  std::unordered_map<PFLayer::Layer, const CaloSubdetectorGeometry*> hcalGeo;
+};
+
+void LegacyPFRecHitProducer::beginRun(edm::Run const&, const edm::EventSetup& setup) {
+  geoHandle = setup.getHandle(geomToken);
+  hcalGeo[PFLayer::HCAL_BARREL1] = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
+  hcalGeo[PFLayer::HCAL_ENDCAP] = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalEndcap);
+}
+
+void LegacyPFRecHitProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+  edm::Handle<reco::PFRecHitHostCollection> pfRecHitsAlpakaSoA;
+  event.getByToken(alpakaPfRecHitsToken, pfRecHitsAlpakaSoA);
+  const reco::PFRecHitHostCollection::ConstView& alpakaPfRecHits = pfRecHitsAlpakaSoA->const_view();
+
+  reco::PFRecHitCollection out;
+  out.reserve(alpakaPfRecHits.size());
+
+  for(size_t i = 0; i < alpakaPfRecHits.size(); i++) {
+    reco::PFRecHit& pfrh = out.emplace_back(
+      hcalGeo.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()),
+      alpakaPfRecHits[i].detId(),
+      alpakaPfRecHits[i].layer(),
+      alpakaPfRecHits[i].energy());
+    pfrh.setTime(alpakaPfRecHits[i].time());
+    pfrh.setDepth(alpakaPfRecHits[i].depth());
+
+    // order in Alpaka:   N, S, E, W,NE,SW,SE,NW
+    const short eta[8] = {0, 0, 1,-1, 1,-1, 1,-1};
+    const short phi[8] = {1,-1, 0, 0, 1,-1,-1, 1};
+    for(size_t k = 0; k < 8; k++)
+      if(alpakaPfRecHits[i].neighbours()(k) != -1)
+        pfrh.addNeighbour(eta[k], phi[k], 0, alpakaPfRecHits[i].neighbours()(k));
+  }
+
+  event.emplace(legacyPfRecHitsToken, out);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(LegacyPFRecHitProducer);
+// */

--- a/RecoParticleFlow/PFRecHitProducer/plugins/PFRecHitProducerTest.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/PFRecHitProducerTest.cc
@@ -37,6 +37,7 @@ private:
   edm::EDGetTokenT<reco::PFRecHitHostCollection> pfRecHitsTokenAlpaka;
   int32_t num_events = 0, num_errors = 0;
 
+  // Container for PFRecHit, independent of how it was constructed
   struct GenericPFRecHit {
     uint32_t detId;
     int depth;
@@ -46,8 +47,8 @@ private:
     float x, y, z;
     std::vector<uint32_t> neighbours4, neighbours8;
 
-    GenericPFRecHit(const reco::PFRecHit& pfRecHit);  // Constructor from legacy
-    GenericPFRecHit(const reco::PFRecHitHostCollection::ConstView& pfRecHitsAlpaka, size_t i);  // Constructor from Alpaka
+    GenericPFRecHit(const reco::PFRecHit& pfRecHit);  // Constructor from legacy format
+    GenericPFRecHit(const reco::PFRecHitHostCollection::ConstView& pfRecHitsAlpaka, size_t i);  // Constructor from Alpaka SoA
 
     void Print(const char* prefix, size_t idx);
     int Compare(const GenericPFRecHit& other);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
@@ -51,7 +51,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("src");
-      desc.add<bool>("synchronise");
+      desc.add<bool>("synchronise", false);
       descriptions.addWithDefaultLabel(desc);
     }
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitHBHETopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitHBHETopologyESProducer.cc
@@ -98,9 +98,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         view.positionZ()[index] = pos.z();
 
         auto neigh = navicore.get()->getNeighbours(denseId);
+        // order from navigator: S, SE, SW, E,  W, NE, NW,  N
+        // desired order for PF: N,  S,  E, W, NE, SW, SE, NW
+        const uint32_t order[8] = {1, 6, 5, 2, 3, 4, 7, 0};
 
         for (uint32_t n = 0; n < 8; ++n) {
-          view[index].neighbours()(n) = 0xffffffff;
+          view[index].neighbours()(order[n]) = 0xffffffff;
 
           // cmssdt.cern.ch/lxr/source/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h#0087
           // Order: CENTER(NONE),SOUTH,SOUTHEAST,SOUTHWEST,EAST,WEST,NORTHEAST,NORTHWEST,NORTH
@@ -115,7 +118,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           if (neighDenseId < denseIdMin or neighDenseId > denseIdMax)
             continue;
 
-          view[index].neighbours()(n) = neighDenseId - denseIdMin;
+          view[index].neighbours()(order[n]) = neighDenseId - denseIdMin;
         }
 
         logDebug() << "detId: rawId=" << hid.rawId() << " subdet=" << hid.subdet() << " index=" << index;

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerAlpaka.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerAlpaka.cc
@@ -48,7 +48,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       desc.add<edm::InputTag>("src");
       desc.add<edm::ESInputTag>("params");
       desc.add<edm::ESInputTag>("topology");
-      desc.add<bool>("synchronise");
+      desc.add<bool>("synchronise", false);
       descriptions.addWithDefaultLabel(desc);
     }
 

--- a/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
@@ -36,7 +36,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_12_4_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_124X_mcRun3_2022_realistic_v5-v1/10000/012eda92-aad5-4a95-8dbd-c79546b5f508.root'),
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/05ad6501-815f-4df6-b115-03ad028f9b76.root'),
     secondaryFileNames = cms.untracked.vstring()
 )
 

--- a/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
@@ -247,20 +247,25 @@ process.hltParticleFlowPFRecHitAlpaka = cms.EDProducer(alpaka_backend_str % "PFR
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 process.hltParticleFlowPFRecHitComparison = DQMEDAnalyzer("PFRecHitProducerTest",
     recHitsSourceCPU = cms.untracked.InputTag("hltHbhereco"),
-    pfRecHitsSourceCPU = cms.untracked.InputTag("hltParticleFlowRecHitHBHE"),
-    pfRecHitsSourceAlpaka = cms.untracked.InputTag("hltParticleFlowPFRecHitAlpaka")
+    pfRecHitsSource1 = cms.untracked.InputTag("hltParticleFlowRecHitHBHE"),
+    pfRecHitsSource2 = cms.untracked.InputTag("hltParticleFlowPFRecHitAlpaka"),
+    pfRecHitsType1 = cms.untracked.string("legacy"),
+    pfRecHitsType2 = cms.untracked.string("alpaka"),
+    title = cms.untracked.string("Legacy vs Alpaka")
 )
 
-####
+# Convert Alpaka PFRecHits to legacy format and validate against CPU implementation
 process.htlParticleFlowAlpakaToLegacyPFRecHits = cms.EDProducer("LegacyPFRecHitProducer",
     src = cms.InputTag("hltParticleFlowPFRecHitAlpaka")
 )
 process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison = DQMEDAnalyzer("PFRecHitProducerTest",
     recHitsSourceCPU = cms.untracked.InputTag("hltHbhereco"),
-    pfRecHitsSourceCPU = cms.untracked.InputTag("htlParticleFlowAlpakaToLegacyPFRecHits"),
-    pfRecHitsSourceAlpaka = cms.untracked.InputTag("hltParticleFlowPFRecHitAlpaka")
+    pfRecHitsSource1 = cms.untracked.InputTag("hltParticleFlowRecHitHBHE"),
+    pfRecHitsSource2 = cms.untracked.InputTag("htlParticleFlowAlpakaToLegacyPFRecHits"),
+    pfRecHitsType1 = cms.untracked.string("legacy"),
+    pfRecHitsType2 = cms.untracked.string("legacy"),
+    title = cms.untracked.string("Legacy vs Legacy-from-Alpaka")
 )
-####
 
 
 #
@@ -284,13 +289,9 @@ process.HBHEPFCPUGPUTask = cms.Path(
     +process.hltParticleFlowRecHitHBHE      # Construct PFRecHits on CPU
     +process.hltParticleFlowRecHitToSoA     # Convert legacy CaloRecHits to SoA and copy to device
     +process.hltParticleFlowPFRecHitAlpaka  # Construct PFRecHits on device
-    #+process.hltParticleFlowPFRecHitComparison  # Validate Alpaka vs CPU
-
-####
+    +process.hltParticleFlowPFRecHitComparison  # Validate Alpaka vs CPU
     +process.htlParticleFlowAlpakaToLegacyPFRecHits             # Convert Alpaka PFRecHits to legacy format
-    +process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison   # Compare converted legacy format to Alpaka
-####
-
+    +process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison   # Validate legacy-format-from-alpaka vs regular legacy format
 )
 process.schedule = cms.Schedule(process.HBHEPFCPUGPUTask)
 process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])

--- a/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
@@ -251,6 +251,18 @@ process.hltParticleFlowPFRecHitComparison = DQMEDAnalyzer("PFRecHitProducerTest"
     pfRecHitsSourceAlpaka = cms.untracked.InputTag("hltParticleFlowPFRecHitAlpaka")
 )
 
+####
+process.htlParticleFlowAlpakaToLegacyPFRecHits = cms.EDProducer("LegacyPFRecHitProducer",
+    src = cms.InputTag("hltParticleFlowPFRecHitAlpaka")
+)
+process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison = DQMEDAnalyzer("PFRecHitProducerTest",
+    recHitsSourceCPU = cms.untracked.InputTag("hltHbhereco"),
+    pfRecHitsSourceCPU = cms.untracked.InputTag("htlParticleFlowAlpakaToLegacyPFRecHits"),
+    pfRecHitsSourceAlpaka = cms.untracked.InputTag("hltParticleFlowPFRecHitAlpaka")
+)
+####
+
+
 #
 # Additional customization
 process.FEVTDEBUGHLToutput.outputCommands = cms.untracked.vstring('drop  *_*_*_*')
@@ -272,7 +284,13 @@ process.HBHEPFCPUGPUTask = cms.Path(
     +process.hltParticleFlowRecHitHBHE      # Construct PFRecHits on CPU
     +process.hltParticleFlowRecHitToSoA     # Convert legacy CaloRecHits to SoA and copy to device
     +process.hltParticleFlowPFRecHitAlpaka  # Construct PFRecHits on device
-    +process.hltParticleFlowPFRecHitComparison  # Validate Alpaka vs CPU
+    #+process.hltParticleFlowPFRecHitComparison  # Validate Alpaka vs CPU
+
+####
+    +process.htlParticleFlowAlpakaToLegacyPFRecHits             # Convert Alpaka PFRecHits to legacy format
+    +process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison   # Compare converted legacy format to Alpaka
+####
+
 )
 process.schedule = cms.Schedule(process.HBHEPFCPUGPUTask)
 process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])

--- a/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
@@ -158,7 +158,13 @@ parser.add_argument('-s', '--synchronise', action='store_true', default=False,
                     help='Put synchronisation point at the end of Alpaka modules (for benchmarking performance)')
 parser.add_argument('-t', '--threads', type=int, default=8,
                     help='Number of threads. Default: 8')
+parser.add_argument('-d', '--debug', action='store_true', default=False,
+                    help='Dump legacy and Alpaka PFRecHits for first event. Default: off')
 args = parser.parse_args(sys.argv[3:])
+
+if(args.debug and args.threads != 1):
+    args.threads = 1
+    print("Number of threads set to 1 for debugging")
 
 
 #####################################
@@ -252,7 +258,7 @@ process.hltParticleFlowPFRecHitComparison = DQMEDAnalyzer("PFRecHitProducerTest"
     pfRecHitsType1 = cms.untracked.string("legacy"),
     pfRecHitsType2 = cms.untracked.string("alpaka"),
     title = cms.untracked.string("Legacy vs Alpaka"),
-    dumpFirstEvent = cms.untracked.bool(False),  # Set this to True for debugging
+    dumpFirstEvent = cms.untracked.bool(args.debug),  # Set this to True for debugging
     dumpFirstError = cms.untracked.bool(False)
 )
 

--- a/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/pfRecHitProducer_CPU_vs_Alpaka.py
@@ -251,22 +251,35 @@ process.hltParticleFlowPFRecHitComparison = DQMEDAnalyzer("PFRecHitProducerTest"
     pfRecHitsSource2 = cms.untracked.InputTag("hltParticleFlowPFRecHitAlpaka"),
     pfRecHitsType1 = cms.untracked.string("legacy"),
     pfRecHitsType2 = cms.untracked.string("alpaka"),
-    title = cms.untracked.string("Legacy vs Alpaka")
+    title = cms.untracked.string("Legacy vs Alpaka"),
+    dumpFirstEvent = cms.untracked.bool(False),  # Set this to True for debugging
+    dumpFirstError = cms.untracked.bool(False)
 )
 
 # Convert Alpaka PFRecHits to legacy format and validate against CPU implementation
 process.htlParticleFlowAlpakaToLegacyPFRecHits = cms.EDProducer("LegacyPFRecHitProducer",
     src = cms.InputTag("hltParticleFlowPFRecHitAlpaka")
 )
-process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison = DQMEDAnalyzer("PFRecHitProducerTest",
+process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison1 = DQMEDAnalyzer("PFRecHitProducerTest",
     recHitsSourceCPU = cms.untracked.InputTag("hltHbhereco"),
     pfRecHitsSource1 = cms.untracked.InputTag("hltParticleFlowRecHitHBHE"),
     pfRecHitsSource2 = cms.untracked.InputTag("htlParticleFlowAlpakaToLegacyPFRecHits"),
     pfRecHitsType1 = cms.untracked.string("legacy"),
     pfRecHitsType2 = cms.untracked.string("legacy"),
-    title = cms.untracked.string("Legacy vs Legacy-from-Alpaka")
+    title = cms.untracked.string("Legacy vs Legacy-from-Alpaka"),
+    dumpFirstEvent = cms.untracked.bool(False),
+    dumpFirstError = cms.untracked.bool(False)
 )
-
+process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison2 = DQMEDAnalyzer("PFRecHitProducerTest",
+    recHitsSourceCPU = cms.untracked.InputTag("hltHbhereco"),
+    pfRecHitsSource1 = cms.untracked.InputTag("hltParticleFlowPFRecHitAlpaka"),
+    pfRecHitsSource2 = cms.untracked.InputTag("htlParticleFlowAlpakaToLegacyPFRecHits"),
+    pfRecHitsType1 = cms.untracked.string("alpaka"),
+    pfRecHitsType2 = cms.untracked.string("legacy"),
+    title = cms.untracked.string("Alpaka vs Legacy-from-Alpaka"),
+    dumpFirstEvent = cms.untracked.bool(False),
+    dumpFirstError = cms.untracked.bool(False)
+)
 
 #
 # Additional customization
@@ -291,7 +304,8 @@ process.HBHEPFCPUGPUTask = cms.Path(
     +process.hltParticleFlowPFRecHitAlpaka  # Construct PFRecHits on device
     +process.hltParticleFlowPFRecHitComparison  # Validate Alpaka vs CPU
     +process.htlParticleFlowAlpakaToLegacyPFRecHits             # Convert Alpaka PFRecHits to legacy format
-    +process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison   # Validate legacy-format-from-alpaka vs regular legacy format
+    +process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison1  # Validate legacy-format-from-alpaka vs regular legacy format
+    +process.htlParticleFlowAlpakaToLegacyPFRecHitsComparison2  # Validate Alpaka format vs legacy-format-from-alpaka
 )
 process.schedule = cms.Schedule(process.HBHEPFCPUGPUTask)
 process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])

--- a/RecoParticleFlow/PFRecHitProducer/test/read_hcal_recHits.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/read_hcal_recHits.py
@@ -1,0 +1,277 @@
+# Auto generated configuration file
+# using:
+# Revision: 1.19
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v
+# with command line options: reHLT --processName reHLT -s HLT:@relval2021 --conditions auto:phase1_2021_realistic --datatier GEN-SIM-DIGI-RAW -n 5 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --customise=HLTrigger/Configuration/customizeHLTforPatatrack.customizeHLTforPatatrack --filein /store/relval/CMSSW_12_3_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v6-v1/10000/2639d8f2-aaa6-4a78-b7c2-9100a6717e6c.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('rereHLT',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('HLTrigger.Configuration.HLT_GRun_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.load("RecoParticleFlow.PFClusterProducer.pfhbheRecHitParamsGPUESProducer_cfi")
+process.load("RecoParticleFlow.PFClusterProducer.pfhbheTopologyGPUESProducer_cfi")
+
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.maxEvents = cms.untracked.PSet(
+    #input = cms.untracked.int32(5),
+    #input = cms.untracked.int32(100),
+    input = cms.untracked.int32(10000),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:/data/user/florkows/hcal_recHits.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('reHLT nevts:5'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('hcal_recHits_processed.root'),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+from HLTrigger.Configuration.CustomConfigs import ProcessName
+process = ProcessName(process)
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
+
+# Path and EndPath definitions
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+# Schedule definition
+# process.schedule imported from cff in HLTrigger.Configuration
+process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforPatatrack
+#from HLTrigger.Configuration.customizeHLTforPatatrack import customizeHLTforPatatrack, customiseCommon, customiseHcalLocalReconstruction
+
+# only enable Hcal GPU
+#process = customiseCommon(process)
+#process = customiseHcalLocalReconstruction(process)
+
+#call to customisation function customizeHLTforPatatrack imported from HLTrigger.Configuration.customizeHLTforPatatrack
+#process = customizeHLTforPatatrack(process)
+
+# Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforMC
+from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC
+
+#call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
+process = customizeHLTforMC(process)
+
+# End of customisation functions
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+
+process.load( "HLTrigger.Timer.FastTimerService_cfi" )
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.TriggerSummaryProducerAOD = cms.untracked.PSet()
+    process.MessageLogger.L1GtTrigReport = cms.untracked.PSet()
+    process.MessageLogger.L1TGlobalSummary = cms.untracked.PSet()
+    process.MessageLogger.HLTrigReport = cms.untracked.PSet()
+    process.MessageLogger.FastReport = cms.untracked.PSet()
+    process.MessageLogger.ThroughputService = cms.untracked.PSet()
+    process.MessageLogger.cerr.FastReport = cms.untracked.PSet( limit = cms.untracked.int32( 10000000 ) )
+
+
+
+
+
+import sys
+import argparse
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Throughput test of PFRecHitProducer with Alpaka')
+parser.add_argument('-b', '--backend', type=str, default='legacy',
+                    help='Alpaka backend. Possible options: legacy, CPU, GPU, auto. Default: CPU')
+parser.add_argument('-s', '--synchronise', action='store_true', default=False,
+                    help='Put synchronisation point at the end of Alpaka modules (for benchmarking performance)')
+parser.add_argument('-t', '--threads', type=int, default=8,
+                    help='Number of threads. Default: 8')
+args = parser.parse_args(sys.argv[sys.argv.index("--")+1:] if "--" in sys.argv else [])
+backend = args.backend.lower()
+
+#####################################
+##    Legacy PFRecHit producer     ##
+#####################################
+process.hltParticleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
+    navigator = cms.PSet(
+        hcalEnums = cms.vint32(1, 2),
+        name = cms.string('PFRecHitHCALDenseIdNavigator')
+    ),
+    producers = cms.VPSet(cms.PSet(
+        name = cms.string('PFHBHERecHitCreator'),
+        qualityTests = cms.VPSet(
+            cms.PSet(
+                cuts = cms.VPSet(
+                    cms.PSet(
+                        depth = cms.vint32(1, 2, 3, 4),
+                        detectorEnum = cms.int32(1),
+                        threshold = cms.vdouble(0.1, 0.2, 0.3, 0.3)
+                    ),
+                    cms.PSet(
+                        depth = cms.vint32(1, 2, 3, 4, 5, 6, 7),
+                        detectorEnum = cms.int32(2),
+                        threshold = cms.vdouble(0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2)
+                    )
+                ),
+                name = cms.string('PFRecHitQTestHCALThresholdVsDepth')
+            ),
+            cms.PSet(
+                cleaningThresholds = cms.vdouble(0.0),
+                flags = cms.vstring('Standard'),
+                maxSeverities = cms.vint32(11),
+                name = cms.string('PFRecHitQTestHCALChannel')
+            )
+        ),
+        src = cms.InputTag("hltHbhereco")
+    ))
+)
+
+
+#####################################
+##    Alpaka PFRecHit producer     ##
+#####################################
+if backend == "legacy":
+    pass
+elif backend == "cpu":
+    alpaka_backend_str = "alpaka_serial_sync::%s"   # Execute on CPU
+elif backend == "gpu" or backend == "cuda":
+    alpaka_backend_str = "alpaka_cuda_async::%s"    # Execute using CUDA
+elif backend == "auto":
+    alpaka_backend_str = "%s@alpaka"                # Let framework choose
+else:
+    print("Invalid backend:", backend)
+    sys.exit(1)
+print("Selected backend:", backend)
+
+if backend != "legacy":
+    # Convert legacy CaloRecHits to CaloRecHitSoA
+    process.hltParticleFlowRecHitToSoA = cms.EDProducer(alpaka_backend_str % "CaloRecHitSoAProducer",
+        src = cms.InputTag("hltHbhereco"),
+        synchronise = cms.bool(args.synchronise)
+    )
+
+    # Construct PFRecHitsSoA
+    process.jobConfAlpakaRcdESSource = cms.ESSource('EmptyESSource',
+        recordName = cms.string('JobConfigurationAlpakaRecord'),
+        iovIsRunNotTime = cms.bool(True),
+        firstValid = cms.vuint32(1)
+    )
+    process.pfRecHitHBHETopologyAlpakaESRcdESSource = cms.ESSource('EmptyESSource',
+    recordName = cms.string('PFRecHitHBHETopologyAlpakaESRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+    )
+    process.hltParticleFlowRecHitParamsESProducer = cms.ESProducer(alpaka_backend_str % "PFRecHitHBHEParamsESProducer",
+        energyThresholdsHB = cms.vdouble( 0.1, 0.2, 0.3, 0.3 ),
+        energyThresholdsHE = cms.vdouble( 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2 )
+    )
+    process.hltParticleFlowRecHitTopologyESProducer = cms.ESProducer(alpaka_backend_str % "PFRecHitHBHETopologyESProducer",
+        hcalEnums = cms.vint32(1, 2)
+    )
+    process.hltParticleFlowPFRecHitAlpaka = cms.EDProducer(alpaka_backend_str % "PFRecHitProducerAlpaka",
+        src = cms.InputTag("hltParticleFlowRecHitToSoA"),
+        params = cms.ESInputTag("hltParticleFlowRecHitParamsESProducer:"),
+        topology = cms.ESInputTag("hltParticleFlowRecHitTopologyESProducer:"),
+        synchronise = cms.bool(args.synchronise)
+    )
+
+#
+# Additional customization
+process.FEVTDEBUGHLToutput.outputCommands = cms.untracked.vstring('drop *_*_*_*')
+#process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*ParticleFlow*HBHE*_*_*')
+#process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*HbherecoLegacy*_*_*')
+##process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*HbherecoFromGPU*_*_*')
+#process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*Hbhereco*_*_*')
+#process.FEVTDEBUGHLToutput.outputCommands.append('keep *_hltParticleFlowRecHitToSoA_*_*')
+#process.FEVTDEBUGHLToutput.outputCommands.append('keep *_hltParticleFlowPFRecHitAlpaka_*_*')
+
+#
+# Run only localreco, PFRecHit and PFCluster producers for HBHE only
+#process.source.fileNames = cms.untracked.vstring('file:/cms/data/hatake/ana/PF/GPU/CMSSW_12_4_0_v2/src/test/v21/GPU/reHLT_HLT.root ')
+
+# Path/sequence definitions
+if backend == "legacy":
+    process.HBHEPFCPUGPUTask = cms.Path(
+        process.hltParticleFlowRecHitHBHE
+    )
+else:
+    process.HBHEPFCPUGPUTask = cms.Path(
+        process.hltParticleFlowRecHitToSoA      # Convert legacy CaloRecHits to SoA and copy to device
+        +process.hltParticleFlowPFRecHitAlpaka  # Construct PFRecHits on device
+    )
+process.schedule = cms.Schedule(process.HBHEPFCPUGPUTask)
+process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
+
+process.options.numberOfThreads = cms.untracked.uint32(args.threads)

--- a/RecoParticleFlow/PFRecHitProducer/test/store_hcal_recHits.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/store_hcal_recHits.py
@@ -1,0 +1,186 @@
+# Auto generated configuration file
+# using:
+# Revision: 1.19
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v
+# with command line options: reHLT --processName reHLT -s HLT:@relval2021 --conditions auto:phase1_2021_realistic --datatier GEN-SIM-DIGI-RAW -n 5 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --customise=HLTrigger/Configuration/customizeHLTforPatatrack.customizeHLTforPatatrack --filein /store/relval/CMSSW_12_3_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v6-v1/10000/2639d8f2-aaa6-4a78-b7c2-9100a6717e6c.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('rereHLTprepareHCAL',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('HLTrigger.Configuration.HLT_GRun_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.load("RecoParticleFlow.PFClusterProducer.pfhbheRecHitParamsGPUESProducer_cfi")
+process.load("RecoParticleFlow.PFClusterProducer.pfhbheTopologyGPUESProducer_cfi")
+
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.maxEvents = cms.untracked.PSet(
+    #input = cms.untracked.int32(5),
+    #input = cms.untracked.int32(100),
+    input = cms.untracked.int32(10000),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring([
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/04753ba2-a821-43ec-b5e5-39f71c3e666d.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/05ad6501-815f-4df6-b115-03ad028f9b76.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0ae805d3-d18a-4e42-b194-3eca35d5af48.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0ba1c8ac-bd60-4d36-ad0e-27dd618f3d84.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0e060b28-dbdb-420f-9f32-150285085ecd.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0ea01168-52a6-4be1-9c95-0e3a394f4516.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0f2fa2ed-ac2d-4ad3-b646-1a0ae08497bc.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/113a010d-5a23-4e64-bf19-96eeaddc5c79.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/11bbf6a4-5f18-4438-9dcf-a782b3e1ddd2.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/1550161b-3b14-488f-bef3-ba7083b09554.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/16e2c156-2679-4641-9150-2d677afa208d.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/174d4f9e-826e-47eb-9525-fc95022a6d17.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/182ea5ab-9093-487f-92ef-574c0948c862.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/186daa22-7740-4b22-a3a7-16012ebacaa0.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/1d20b7ad-7aa9-439d-b109-d16a8911ef6b.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/1fa10cef-9661-4bc1-bf29-505bf4930cec.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/219bdf10-8b9a-45b8-8507-bcfd5b9e0769.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/23e7af8d-a3ac-4203-9384-db44e4efb3c3.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/282a9817-c8af-4611-8284-2c333fb139d3.root',
+        '/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/293b83b0-35e9-4a6c-87b8-4c8ec199abdf.root'
+    ]),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('reHLT nevts:5'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('/data/user/florkows/hcal_recHits.root'),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+from HLTrigger.Configuration.CustomConfigs import ProcessName
+process = ProcessName(process)
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
+
+# Path and EndPath definitions
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+
+# Schedule definition
+# process.schedule imported from cff in HLTrigger.Configuration
+process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforPatatrack
+#from HLTrigger.Configuration.customizeHLTforPatatrack import customizeHLTforPatatrack, customiseCommon, customiseHcalLocalReconstruction
+
+# only enable Hcal GPU
+#process = customiseCommon(process)
+#process = customiseHcalLocalReconstruction(process)
+
+#call to customisation function customizeHLTforPatatrack imported from HLTrigger.Configuration.customizeHLTforPatatrack
+#process = customizeHLTforPatatrack(process)
+
+# Automatic addition of the customisation function from HLTrigger.Configuration.customizeHLTforMC
+from HLTrigger.Configuration.customizeHLTforMC import customizeHLTforMC
+
+#call to customisation function customizeHLTforMC imported from HLTrigger.Configuration.customizeHLTforMC
+process = customizeHLTforMC(process)
+
+# End of customisation functions
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion
+
+process.load( "HLTrigger.Timer.FastTimerService_cfi" )
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.TriggerSummaryProducerAOD = cms.untracked.PSet()
+    process.MessageLogger.L1GtTrigReport = cms.untracked.PSet()
+    process.MessageLogger.L1TGlobalSummary = cms.untracked.PSet()
+    process.MessageLogger.HLTrigReport = cms.untracked.PSet()
+    process.MessageLogger.FastReport = cms.untracked.PSet()
+    process.MessageLogger.ThroughputService = cms.untracked.PSet()
+    process.MessageLogger.cerr.FastReport = cms.untracked.PSet( limit = cms.untracked.int32( 10000000 ) )
+
+#
+# Additional customization
+process.FEVTDEBUGHLToutput.outputCommands = cms.untracked.vstring('drop *_*_*_*')
+process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*Hbhereco*_*_*')
+
+#
+# Run only localreco, PFRecHit and PFCluster producers for HBHE only
+#process.source.fileNames = cms.untracked.vstring('file:/cms/data/hatake/ana/PF/GPU/CMSSW_12_4_0_v2/src/test/v21/GPU/reHLT_HLT.root ')
+
+# Path/sequence definitions
+process.HBHEPFCPUGPUTask = cms.Path(
+    process.hltHcalDigis
+    +process.hltHbherecoLegacy
+)
+process.schedule = cms.Schedule(process.HBHEPFCPUGPUTask)
+process.schedule.extend([process.endjob_step,process.FEVTDEBUGHLToutput_step])
+
+process.options.numberOfThreads = cms.untracked.uint32(32)

--- a/RecoParticleFlow/PFRecHitProducer/test/store_hcal_recHits.py
+++ b/RecoParticleFlow/PFRecHitProducer/test/store_hcal_recHits.py
@@ -105,6 +105,8 @@ process.FEVTDEBUGHLToutput = cms.OutputModule("PoolOutputModule",
         filterName = cms.untracked.string('')
     ),
     fileName = cms.untracked.string('/data/user/florkows/hcal_recHits.root'),
+    #fileName = cms.untracked.string('/data/user/florkows/hcal_recHits_uncompressed.root'),
+    #compressionLevel = cms.untracked.int32(0),
     outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
     splitLevel = cms.untracked.int32(0)
 )
@@ -169,7 +171,8 @@ if 'MessageLogger' in process.__dict__:
 #
 # Additional customization
 process.FEVTDEBUGHLToutput.outputCommands = cms.untracked.vstring('drop *_*_*_*')
-process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*Hbhereco*_*_*')
+process.FEVTDEBUGHLToutput.outputCommands.append('keep *_hltHbhereco_*_*')
+#process.FEVTDEBUGHLToutput.outputCommands.append('keep *_hltHbherecoLegacy_*_*')
 
 #
 # Run only localreco, PFRecHit and PFCluster producers for HBHE only


### PR DESCRIPTION
New commits:
- make PFRecHit validation independent of ordering, such that legacy <-> Alpaka validation succeeds
- add Alpaka PFRecHit to legacy format conversion
- add legacy <-> legacy-from-Alpaka validation
- add Alpaka <-> legacy-from-Alpaka validation
- (commented out: add legacy <-> legacy-from-CUDA validation, using the legacy PFRecHits that are created by the CUDA module)

Commits from Hackathon that are included here for some reason:
- optimise performance Alpaka PFRecHitProducer on GPU
- add configuration that stores HCAL recHits to Root file
- add configuration that constructs PFRecHits based on said file (preparation for benchmarking)